### PR TITLE
feat: add support for cumulative, non-monotonic sums

### DIFF
--- a/otel2influx/metrics_telegraf_prometheus_v2.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2.go
@@ -21,7 +21,10 @@ func (c *metricWriterTelegrafPrometheusV2) writeMetric(ctx context.Context, reso
 	case pdata.MetricDataTypeGauge:
 		return c.writeGauge(ctx, resource, instrumentationLibrary, metric.Name(), metric.Gauge(), w)
 	case pdata.MetricDataTypeSum:
-		return c.writeSum(ctx, resource, instrumentationLibrary, metric.Name(), metric.Sum(), w)
+		if metric.Sum().IsMonotonic() {
+			return c.writeSum(ctx, resource, instrumentationLibrary, metric.Name(), metric.Sum(), w)
+		}
+		return c.writeGaugeFromSum(ctx, resource, instrumentationLibrary, metric.Name(), metric.Sum(), w)
 	case pdata.MetricDataTypeHistogram:
 		return c.writeHistogram(ctx, resource, instrumentationLibrary, metric.Name(), metric.Histogram(), w)
 	case pdata.MetricDataTypeSummary:
@@ -92,12 +95,40 @@ func (c *metricWriterTelegrafPrometheusV2) writeGauge(ctx context.Context, resou
 	return nil
 }
 
+func (c *metricWriterTelegrafPrometheusV2) writeGaugeFromSum(ctx context.Context, resource pdata.Resource, instrumentationLibrary pdata.InstrumentationLibrary, measurement string, sum pdata.Sum, w InfluxWriter) error {
+	if sum.AggregationTemporality() != pdata.MetricAggregationTemporalityCumulative {
+		return fmt.Errorf("unsupported sum (as gauge) aggregation temporality %q", sum.AggregationTemporality())
+	}
+
+	for i := 0; i < sum.DataPoints().Len(); i++ {
+		dataPoint := sum.DataPoints().At(i)
+		tags, fields, ts, err := c.initMetricTagsAndTimestamp(resource, instrumentationLibrary, dataPoint.Timestamp(), dataPoint.Attributes())
+		if err != nil {
+			return err
+		}
+
+		switch dataPoint.ValueType() {
+		case pdata.MetricValueTypeNone:
+			continue
+		case pdata.MetricValueTypeDouble:
+			fields[measurement] = dataPoint.DoubleVal()
+		case pdata.MetricValueTypeInt:
+			fields[measurement] = dataPoint.IntVal()
+		default:
+			return fmt.Errorf("unsupported sum (as gauge) data point type %d", dataPoint.ValueType())
+		}
+
+		if err = w.WritePoint(ctx, common.MeasurementPrometheus, tags, fields, ts, common.InfluxMetricValueTypeGauge); err != nil {
+			return fmt.Errorf("failed to write point for sum (as gauge): %w", err)
+		}
+	}
+
+	return nil
+}
+
 func (c *metricWriterTelegrafPrometheusV2) writeSum(ctx context.Context, resource pdata.Resource, instrumentationLibrary pdata.InstrumentationLibrary, measurement string, sum pdata.Sum, w InfluxWriter) error {
 	if sum.AggregationTemporality() != pdata.MetricAggregationTemporalityCumulative {
 		return fmt.Errorf("unsupported sum aggregation temporality %q", sum.AggregationTemporality())
-	}
-	if !sum.IsMonotonic() {
-		return fmt.Errorf("unsupported non-monotonic sum '%s'", measurement)
 	}
 
 	for i := 0; i < sum.DataPoints().Len(); i++ {

--- a/otel2influx/metrics_telegraf_prometheus_v2_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2_test.go
@@ -74,6 +74,70 @@ func TestWriteMetric_v2_gauge(t *testing.T) {
 	assert.EqualValues(t, expected, w.points)
 }
 
+func TestWriteMetric_v2_gaugeFromSum(t *testing.T) {
+	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), common.MetricsSchemaTelegrafPrometheusV2)
+	require.NoError(t, err)
+
+	metrics := pdata.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().InsertString("node", "42")
+	ilMetrics := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ilMetrics.InstrumentationLibrary().SetName("My Library")
+	ilMetrics.InstrumentationLibrary().SetVersion("latest")
+	m := ilMetrics.Metrics().AppendEmpty()
+	m.SetName("cache_age_seconds")
+	m.SetDescription("Age in seconds of the current cache")
+	m.SetDataType(pdata.MetricDataTypeSum)
+	m.Sum().SetIsMonotonic(false)
+	m.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+	dp := m.Sum().DataPoints().AppendEmpty()
+	dp.Attributes().InsertInt("engine_id", 0)
+	dp.SetTimestamp(pdata.Timestamp(1395066363000000123))
+	dp.SetDoubleVal(23.9)
+	dp = m.Sum().DataPoints().AppendEmpty()
+	dp.Attributes().InsertInt("engine_id", 1)
+	dp.SetTimestamp(pdata.Timestamp(1395066363000000123))
+	dp.SetDoubleVal(11.9)
+
+	w := new(MockInfluxWriter)
+
+	err = c.WriteMetrics(context.Background(), metrics, w)
+	require.NoError(t, err)
+
+	expected := []mockPoint{
+		{
+			measurement: "prometheus",
+			tags: map[string]string{
+				"node":                 "42",
+				"otel.library.name":    "My Library",
+				"otel.library.version": "latest",
+				"engine_id":            "0",
+			},
+			fields: map[string]interface{}{
+				"cache_age_seconds": float64(23.9),
+			},
+			ts:    time.Unix(0, 1395066363000000123).UTC(),
+			vType: common.InfluxMetricValueTypeGauge,
+		},
+		{
+			measurement: "prometheus",
+			tags: map[string]string{
+				"node":                 "42",
+				"otel.library.name":    "My Library",
+				"otel.library.version": "latest",
+				"engine_id":            "1",
+			},
+			fields: map[string]interface{}{
+				"cache_age_seconds": float64(11.9),
+			},
+			ts:    time.Unix(0, 1395066363000000123).UTC(),
+			vType: common.InfluxMetricValueTypeGauge,
+		},
+	}
+
+	assert.EqualValues(t, expected, w.points)
+}
+
 func TestWriteMetric_v2_sum(t *testing.T) {
 	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), common.MetricsSchemaTelegrafPrometheusV2)
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #50 

When converting from OTel to line protocol with either of the Prometheus-style schemata, we follow the [OTel guidance for Prometheus](https://github.com/open-telemetry/opentelemetry-specification/blob/49a3a1add39c74c659467c8b2a44efc3e1bb23eb/specification/metrics/datamodel.md#otlp-metric-points-to-prometheus). Specifically:

> OpenTelemetry Sums follows this logic:
> ...
> If the aggregation temporality is cumulative and the sum is non-monotonic, it MUST be converted to a Prometheus Gauge.