### PR TITLE
Eliminate usage of removed OTLP LogRecord.Name field

### DIFF
--- a/otel2influx/logs.go
+++ b/otel2influx/logs.go
@@ -52,9 +52,6 @@ func (c *OtelLogsToLineProtocol) writeLogRecord(ctx context.Context, resource pd
 	tags = ResourceToTags(c.logger, resource, tags)
 	tags = InstrumentationLibraryToTags(instrumentationLibrary, tags)
 
-	if name := logRecord.Name(); name != "" {
-		fields[common.AttributeName] = name
-	}
 	if traceID := logRecord.TraceID(); !traceID.IsEmpty() {
 		tags[common.AttributeTraceID] = traceID.HexString()
 		if spanID := logRecord.SpanID(); !spanID.IsEmpty() {

--- a/tests-integration/test_fodder.go
+++ b/tests-integration/test_fodder.go
@@ -135,7 +135,6 @@ spans,kind=SPAN_KIND_CONSUMER,name=process_batch,span_id=0000000000000005,trace_
 		rl := logs.ResourceLogs().AppendEmpty()
 		ilLog := rl.InstrumentationLibraryLogs().AppendEmpty()
 		log := ilLog.LogRecords().AppendEmpty()
-		log.SetName("cpu_temp")
 		log.SetTimestamp(pdata.Timestamp(1622848686000000000))
 		log.SetSeverityNumber(pdata.SeverityNumberINFO)
 		log.SetSeverityText("info")
@@ -151,7 +150,7 @@ spans,kind=SPAN_KIND_CONSUMER,name=process_batch,span_id=0000000000000005,trace_
 		}{
 			otel: logs,
 			lp: `
-logs,span_id=0000000000000003,trace_id=00000000000000020000000000000001 body="something-happened",k=true,otel.span.dropped_attributes_count=5u,name="cpu_temp",severity_number=9i,severity_text="info" 1622848686000000000
+logs,span_id=0000000000000003,trace_id=00000000000000020000000000000001 body="something-happened",k=true,otel.span.dropped_attributes_count=5u,severity_number=9i,severity_text="info" 1622848686000000000
 `,
 		})
 	}


### PR DESCRIPTION
LogRecord.Name is no longer part of the OTLP data model and was deprecated
https://github.com/open-telemetry/opentelemetry-proto/pull/357 and
deleted https://github.com/open-telemetry/opentelemetry-proto/pull/373 from OTLP.

It is now deprecated in the Collector codebase too:
https://github.com/open-telemetry/opentelemetry-collector/blob/d2e5601b7045a3021009729ce539cb88373f3216/model/internal/pdata/generated_log.go#L644

We are planning to delete it from the Collector codebase, but first we need
to remove the references from this codebase since it is a Collector dependency.

Testing done: cd otel2influx && go test ./...