### PR TITLE
feat: add support for temporality tag

### DIFF
--- a/influx2otel/metrics_telegraf_prometheus_v1.go
+++ b/influx2otel/metrics_telegraf_prometheus_v1.go
@@ -87,6 +87,16 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 		dataPoint := metric.Gauge().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+		// set start_time, if exists and is RFC3339
+		// used by statsd input plugin
+		if startTimeObj, ok := fields["start_time"]; ok {
+			if startTimeStr, ok := startTimeObj.(string); ok {
+				if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
+					dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
+				}
+			}
+		}
+
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
 		} else if intValue != nil {
@@ -94,13 +104,18 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 		} else {
 			panic("unreachable")
 		}
-
 		return nil
 	}
 
 	for k, fieldValue := range fields {
 		var floatValue *float64
 		var intValue *int64
+
+		// start_time is a metadata field about the metric,
+		// provided by statsd plugin.
+		if k == "start_time" {
+			continue
+		}
 		switch typedValue := fieldValue.(type) {
 		case float64:
 			floatValue = &typedValue
@@ -122,6 +137,16 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 		dataPoint := metric.Gauge().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+		// set start_time, if exists and is RFC3339
+		// used by statsd input plugin
+		if startTimeObj, ok := fields["start_time"]; ok {
+			if startTimeStr, ok := startTimeObj.(string); ok {
+				if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
+					dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
+				}
+			}
+		}
+
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
 		} else if intValue != nil {
@@ -157,6 +182,16 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 		dataPoint := metric.Sum().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+		// set start_time, if exists and is RFC3339
+		// used by statsd input plugin
+		if startTimeObj, ok := fields["start_time"]; ok {
+			if startTimeStr, ok := startTimeObj.(string); ok {
+				if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
+					dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
+				}
+			}
+		}
+
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
 		} else if intValue != nil {
@@ -169,6 +204,12 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 	}
 
 	for k, fieldValue := range fields {
+		// start_time is a metadata field about the metric,
+		// provided by statsd plugin.
+		if k == "start_time" {
+			continue
+		}
+
 		var floatValue *float64
 		var intValue *int64
 		switch typedValue := fieldValue.(type) {
@@ -192,6 +233,16 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 		dataPoint := metric.Sum().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+		// set start_time, if exists and is RFC3339
+		// used by statsd input plugin
+		if startTimeObj, ok := fields["start_time"]; ok {
+			if startTimeStr, ok := startTimeObj.(string); ok {
+				if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
+					dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
+				}
+			}
+		}
+
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
 		} else if intValue != nil {
@@ -236,6 +287,7 @@ func (b *MetricsBatch) convertHistogramV1(measurement string, tags map[string]st
 				bucketCounts = append(bucketCounts, uint64(vBucketCount))
 			}
 
+		} else if k == "start_time" {
 		} else {
 			b.logger.Debug("skipping unrecognized histogram field", "field", k, "value", vi)
 		}
@@ -271,6 +323,16 @@ func (b *MetricsBatch) convertHistogramV1(measurement string, tags map[string]st
 	dataPoint := metric.Histogram().DataPoints().AppendEmpty()
 	attributes.CopyTo(dataPoint.Attributes())
 	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+	// set start_time, if exists and is RFC3339
+	// used by statsd input plugin
+	if startTimeObj, ok := fields["start_time"]; ok {
+		if startTimeStr, ok := startTimeObj.(string); ok {
+			if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
+				dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
+			}
+		}
+	}
+
 	dataPoint.SetCount(count)
 	dataPoint.SetSum(sum)
 	dataPoint.BucketCounts().FromRaw(bucketCounts)
@@ -310,6 +372,8 @@ func (b *MetricsBatch) convertSummaryV1(measurement string, tags map[string]stri
 				valueAtQuantile.SetValue(value)
 			}
 
+		} else if k == "start_time" {
+
 		} else {
 			b.logger.Debug("skipping unrecognized summary field", "field", k, "value", vi)
 		}
@@ -328,6 +392,16 @@ func (b *MetricsBatch) convertSummaryV1(measurement string, tags map[string]stri
 	dataPoint := metric.Summary().DataPoints().AppendEmpty()
 	attributes.CopyTo(dataPoint.Attributes())
 	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+	// set start_time, if exists and is RFC3339
+	// used by statsd input plugin
+	if startTimeObj, ok := fields["start_time"]; ok {
+		if startTimeStr, ok := startTimeObj.(string); ok {
+			if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
+				dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
+			}
+		}
+	}
+
 	dataPoint.SetCount(count)
 	dataPoint.SetSum(sum)
 	quantileValues.MoveAndAppendTo(dataPoint.QuantileValues())


### PR DESCRIPTION
Add support for delta temporality, the issue is described in https://github.com/influxdata/telegraf/issues/12507 and there is a PR open that adds temporality tag and start_time field for statsd counters https://github.com/influxdata/telegraf/pull/13087