### PR TITLE
feat(influx2otel): add start timestamp to metrics 

### DIFF
--- a/influx2otel/metrics_statsd_schema_test.go
+++ b/influx2otel/metrics_statsd_schema_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestStatsdTimingSchema(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -45,6 +46,7 @@ func TestStatsdTimingSchema(t *testing.T) {
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "timing")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(10)
 
@@ -54,6 +56,7 @@ func TestStatsdTimingSchema(t *testing.T) {
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "timing")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(10)
 
@@ -63,6 +66,7 @@ func TestStatsdTimingSchema(t *testing.T) {
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "timing")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(10)
 
@@ -72,6 +76,7 @@ func TestStatsdTimingSchema(t *testing.T) {
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "timing")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(10)
 
@@ -81,6 +86,7 @@ func TestStatsdTimingSchema(t *testing.T) {
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "timing")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(10)
 
@@ -90,6 +96,7 @@ func TestStatsdTimingSchema(t *testing.T) {
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "timing")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(100)
 
@@ -99,6 +106,7 @@ func TestStatsdTimingSchema(t *testing.T) {
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "timing")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(20)
 
@@ -106,7 +114,8 @@ func TestStatsdTimingSchema(t *testing.T) {
 }
 
 func TestStatsCounter(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	// statsd metric:
@@ -135,6 +144,7 @@ func TestStatsCounter(t *testing.T) {
 	dp := m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "counter")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetIntValue(10)
 
@@ -142,7 +152,8 @@ func TestStatsCounter(t *testing.T) {
 }
 
 func TestStatsGauge(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	// statsd metric:
@@ -170,6 +181,7 @@ func TestStatsGauge(t *testing.T) {
 
 	dp.Attributes().PutStr("metric_type", "gauge")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetIntValue(333)
 
@@ -177,7 +189,8 @@ func TestStatsGauge(t *testing.T) {
 }
 
 func TestStatsdSetsSchema(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	// statsd metric:
@@ -205,6 +218,7 @@ func TestStatsdSetsSchema(t *testing.T) {
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("metric_type", "sets")
 	dp.Attributes().PutStr("type", "app")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetIntValue(1)
 

--- a/influx2otel/metrics_telegraf_prometheus_v1.go
+++ b/influx2otel/metrics_telegraf_prometheus_v1.go
@@ -86,6 +86,7 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 		}
 		dataPoint := metric.Gauge().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
+		dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
@@ -121,6 +122,7 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 		}
 		dataPoint := metric.Gauge().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
+		dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
@@ -156,6 +158,7 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 		}
 		dataPoint := metric.Sum().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
+		dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
@@ -191,6 +194,7 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 		}
 		dataPoint := metric.Sum().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
+		dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
@@ -255,6 +259,7 @@ func (b *MetricsBatch) convertHistogramV1(measurement string, tags map[string]st
 	}
 	dataPoint := metric.Histogram().DataPoints().AppendEmpty()
 	attributes.CopyTo(dataPoint.Attributes())
+	dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 	dataPoint.SetCount(count)
 	dataPoint.SetSum(sum)
@@ -313,6 +318,7 @@ func (b *MetricsBatch) convertSummaryV1(measurement string, tags map[string]stri
 	}
 	dataPoint := metric.Summary().DataPoints().AppendEmpty()
 	attributes.CopyTo(dataPoint.Attributes())
+	dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 	dataPoint.SetCount(count)
 	dataPoint.SetSum(sum)

--- a/influx2otel/metrics_telegraf_prometheus_v1_test.go
+++ b/influx2otel/metrics_telegraf_prometheus_v1_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestAddPoint_v1_gauge(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -57,10 +58,12 @@ func TestAddPoint_v1_gauge(t *testing.T) {
 	m.SetEmptyGauge()
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "0")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(23.9)
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "1")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(11.9)
 
@@ -68,7 +71,8 @@ func TestAddPoint_v1_gauge(t *testing.T) {
 }
 
 func TestAddPoint_v1_untypedGauge(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -111,10 +115,12 @@ func TestAddPoint_v1_untypedGauge(t *testing.T) {
 	m.SetEmptyGauge()
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "0")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(23.9)
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "1")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(11.9)
 
@@ -122,7 +128,8 @@ func TestAddPoint_v1_untypedGauge(t *testing.T) {
 }
 
 func TestAddPoint_v1_sum(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -170,11 +177,13 @@ func TestAddPoint_v1_sum(t *testing.T) {
 	dp := m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(1027)
 	dp = m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "400")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(3)
 
@@ -182,7 +191,8 @@ func TestAddPoint_v1_sum(t *testing.T) {
 }
 
 func TestAddPoint_v1_untypedSum(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -230,11 +240,13 @@ func TestAddPoint_v1_untypedSum(t *testing.T) {
 	dp := m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(1027)
 	dp = m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "400")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(3)
 
@@ -242,7 +254,8 @@ func TestAddPoint_v1_untypedSum(t *testing.T) {
 }
 
 func TestAddPoint_v1_histogram(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -280,6 +293,7 @@ func TestAddPoint_v1_histogram(t *testing.T) {
 	dp := m.Histogram().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetCount(144320)
 	dp.SetSum(53423)
@@ -290,7 +304,8 @@ func TestAddPoint_v1_histogram(t *testing.T) {
 }
 
 func TestAddPoint_v1_untypedHistogram(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -328,6 +343,7 @@ func TestAddPoint_v1_untypedHistogram(t *testing.T) {
 	dp := m.Histogram().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetCount(144320)
 	dp.SetSum(53423)
@@ -338,7 +354,8 @@ func TestAddPoint_v1_untypedHistogram(t *testing.T) {
 }
 
 func TestAddPoint_v1_summary(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -375,6 +392,7 @@ func TestAddPoint_v1_summary(t *testing.T) {
 	dp := m.Summary().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetCount(2693)
 	dp.SetSum(17560473)
@@ -398,7 +416,8 @@ func TestAddPoint_v1_summary(t *testing.T) {
 }
 
 func TestAddPoint_v1_untypedSummary(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -436,6 +455,7 @@ func TestAddPoint_v1_untypedSummary(t *testing.T) {
 	dp := m.Histogram().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetCount(2693)
 	dp.SetSum(17560473)

--- a/influx2otel/metrics_telegraf_prometheus_v2.go
+++ b/influx2otel/metrics_telegraf_prometheus_v2.go
@@ -95,6 +95,7 @@ func (b *MetricsBatch) convertGaugeV2(tags map[string]string, fields map[string]
 	}
 	dataPoint := metric.Gauge().DataPoints().AppendEmpty()
 	attributes.CopyTo(dataPoint.Attributes())
+	dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 	if floatValue != nil {
 		dataPoint.SetDoubleValue(*floatValue)
@@ -135,6 +136,7 @@ func (b *MetricsBatch) convertSumV2(tags map[string]string, fields map[string]in
 	}
 	dataPoint := metric.Sum().DataPoints().AppendEmpty()
 	attributes.CopyTo(dataPoint.Attributes())
+	dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 	if floatValue != nil {
 		dataPoint.SetDoubleValue(*floatValue)
@@ -187,6 +189,7 @@ func (b *MetricsBatch) convertHistogramV2(tags map[string]string, fields map[str
 	if !found {
 		dataPoint = metric.Histogram().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
+		dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		b.histogramDataPointsByMDPK[metric][dpk] = dataPoint
 	}
@@ -286,6 +289,7 @@ func (b *MetricsBatch) convertSummaryV2(tags map[string]string, fields map[strin
 	if !found {
 		dataPoint = metric.Summary().DataPoints().AppendEmpty()
 		attributes.CopyTo(dataPoint.Attributes())
+		dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(b.startTime))
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		b.summaryDataPointsByMDPK[metric][dpk] = dataPoint
 	}

--- a/influx2otel/metrics_telegraf_prometheus_v2_test.go
+++ b/influx2otel/metrics_telegraf_prometheus_v2_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestAddPoint_v2_gauge(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -57,10 +58,12 @@ func TestAddPoint_v2_gauge(t *testing.T) {
 	m.SetEmptyGauge()
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "0")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(23.9)
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "1")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(11.9)
 
@@ -68,7 +71,8 @@ func TestAddPoint_v2_gauge(t *testing.T) {
 }
 
 func TestAddPoint_v2_untypedGauge(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -111,10 +115,12 @@ func TestAddPoint_v2_untypedGauge(t *testing.T) {
 	m.SetEmptyGauge()
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "0")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(23.9)
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "1")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(11.9)
 
@@ -122,7 +128,8 @@ func TestAddPoint_v2_untypedGauge(t *testing.T) {
 }
 
 func TestAddPoint_v2_sum(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -170,11 +177,13 @@ func TestAddPoint_v2_sum(t *testing.T) {
 	dp := m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(1027)
 	dp = m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "400")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(3)
 
@@ -182,7 +191,8 @@ func TestAddPoint_v2_sum(t *testing.T) {
 }
 
 func TestAddPoint_v2_untypedSum(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -228,11 +238,13 @@ func TestAddPoint_v2_untypedSum(t *testing.T) {
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(1027)
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "400")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(3)
 
@@ -240,7 +252,8 @@ func TestAddPoint_v2_untypedSum(t *testing.T) {
 }
 
 func TestAddPoint_v2_histogram(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -354,6 +367,7 @@ func TestAddPoint_v2_histogram(t *testing.T) {
 	dp := m.Histogram().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetCount(144320)
 	dp.SetSum(53423)
@@ -364,7 +378,8 @@ func TestAddPoint_v2_histogram(t *testing.T) {
 }
 
 func TestAddPoint_v2_untypedHistogram(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -478,6 +493,7 @@ func TestAddPoint_v2_untypedHistogram(t *testing.T) {
 	dp := m.Histogram().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetCount(144320)
 	dp.SetSum(53423)
@@ -488,7 +504,8 @@ func TestAddPoint_v2_untypedHistogram(t *testing.T) {
 }
 
 func TestAddPoint_v2_summary(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -601,6 +618,7 @@ func TestAddPoint_v2_summary(t *testing.T) {
 	dp := m.Summary().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetCount(2693)
 	dp.SetSum(17560473)
@@ -624,7 +642,8 @@ func TestAddPoint_v2_summary(t *testing.T) {
 }
 
 func TestAddPoint_v2_untypedSummary(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -738,6 +757,7 @@ func TestAddPoint_v2_untypedSummary(t *testing.T) {
 	dp := m.Histogram().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "200")
 	dp.Attributes().PutStr("method", "post")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetCount(2693)
 	dp.SetSum(17560473)

--- a/influx2otel/metrics_unknown_schema_test.go
+++ b/influx2otel/metrics_unknown_schema_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestUnknownSchema(t *testing.T) {
-	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger))
+	startTime := time.Now()
+	c, err := influx2otel.NewLineProtocolToOtelMetrics(new(common.NoopLogger), startTime)
 	require.NoError(t, err)
 
 	b := c.NewBatch()
@@ -47,6 +48,7 @@ func TestUnknownSchema(t *testing.T) {
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("cpu", "cpu4")
 	dp.Attributes().PutStr("host", "777348dc6343")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(0.10090817356207936)
 	m = ilMetrics.Metrics().AppendEmpty()
@@ -55,6 +57,7 @@ func TestUnknownSchema(t *testing.T) {
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("cpu", "cpu4")
 	dp.Attributes().PutStr("host", "777348dc6343")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(0.3027245206862381)
 	m = ilMetrics.Metrics().AppendEmpty()
@@ -63,6 +66,7 @@ func TestUnknownSchema(t *testing.T) {
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("cpu", "cpu4")
 	dp.Attributes().PutStr("host", "777348dc6343")
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetIntValue(7)
 

--- a/otel2influx/metrics_telegraf_prometheus_v2_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2_test.go
@@ -32,12 +32,10 @@ func TestWriteMetric_v2_gauge(t *testing.T) {
 	m.SetEmptyGauge()
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutInt("engine_id", 0)
-	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(23.9)
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutInt("engine_id", 1)
-	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(11.9)
 

--- a/otel2influx/metrics_telegraf_prometheus_v2_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2_test.go
@@ -32,10 +32,12 @@ func TestWriteMetric_v2_gauge(t *testing.T) {
 	m.SetEmptyGauge()
 	dp := m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutInt("engine_id", 0)
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(23.9)
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutInt("engine_id", 1)
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pcommon.Timestamp(1395066363000000123))
 	dp.SetDoubleValue(11.9)
 


### PR DESCRIPTION
Closes #157
Helps https://github.com/influxdata/telegraf/issues/12664

This change improves otel compatibility by setting the "start timestamp" field when converting from line protocol to otel metrics.

This change breaks the integration tests, which will be fixed with new PRs in Telegraf and OpenTelemetry Collector Contrib.