### PR TITLE
chore: update Jaeger to 1.43.0, and misc Jaeger items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         go: [ "1.19", "1.20" ]
         package: [ "common", "influx2otel", "otel2influx", "jaeger-influxdb", "tests-integration" ]
-#        exclude:
-#        - go: 1.20
-#          package: tests-integration
+        exclude:
+        - go: 1.19
+          package: jaeger-influxdb
     runs-on: ubuntu-latest
     steps:
 

--- a/jaeger-influxdb/Dockerfile
+++ b/jaeger-influxdb/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-FROM golang:1.19-alpine AS builder
+FROM golang:1.20-alpine AS builder
 RUN apk --update --no-cache add ca-certificates
 COPY . /project
 WORKDIR /project/jaeger-influxdb

--- a/jaeger-influxdb/go.mod
+++ b/jaeger-influxdb/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/influxdata/influxdb-observability/common v0.3.4
 	github.com/influxdata/line-protocol/v2 v2.2.1
-	github.com/jaegertracing/jaeger v1.42.0
+	github.com/jaegertracing/jaeger v1.43.0
 	github.com/mattn/go-isatty v0.0.17
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/spf13/cobra v1.6.1
@@ -22,7 +22,7 @@ require (
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/apache/arrow/go/v12 v12.0.0-20230307201612-6fdf1e520a76 // indirect
-	github.com/apache/thrift v0.17.0 // indirect
+	github.com/apache/thrift v0.18.1 // indirect
 	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
@@ -38,7 +38,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
-	github.com/klauspost/compress v1.15.15 // indirect
+	github.com/klauspost/compress v1.16.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/jaeger-influxdb/go.sum
+++ b/jaeger-influxdb/go.sum
@@ -46,8 +46,8 @@ github.com/apache/arrow-adbc/go/adbc v0.3.0 h1:8a2roR2eQ9rfybW+o5o+piwLoim/LZsFC
 github.com/apache/arrow-adbc/go/adbc v0.3.0/go.mod h1:GnOviOwgZGT6IdogE6RP+o5Tjiw+U+2mH7X+WCX9j/w=
 github.com/apache/arrow/go/v12 v12.0.0-20230307201612-6fdf1e520a76 h1:6O9PR51TZFveY6xYg4RCCj23hIFyL7vR5hav0zc+Vss=
 github.com/apache/arrow/go/v12 v12.0.0-20230307201612-6fdf1e520a76/go.mod h1:p9SbFzxqBIUcxDFFqy4aLDT6RdooPoA18Bru+OL1gbk=
-github.com/apache/thrift v0.17.0 h1:cMd2aj52n+8VoAtvSvLn4kDC3aZ6IAkBuqWQ2IDu7wo=
-github.com/apache/thrift v0.17.0/go.mod h1:OLxhMRJxomX+1I/KUw03qoV3mMz16BwaKI+d4fPBx7Q=
+github.com/apache/thrift v0.18.1 h1:lNhK/1nqjbwbiOPDBPFJVKxgDEGSepKuTh6OLiXW8kg=
+github.com/apache/thrift v0.18.1/go.mod h1:rdQn/dCcDKEWjjylUeueum4vQEjG2v8v2PqriUnbr+I=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
 github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
@@ -174,8 +174,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/jaegertracing/jaeger v1.42.0 h1:rT28FEVltmvAvEyiW5trQcd6R8c8W3zYzgNK3Y8k9No=
-github.com/jaegertracing/jaeger v1.42.0/go.mod h1:vjA+lTTRiequdl86TLxEnlofEzgpOGokj+VIjJzwFj4=
+github.com/jaegertracing/jaeger v1.43.0 h1:pk15J3dhwarNJA1WA1SF4DEY8lBaGeeh2dqRvIy1Ke8=
+github.com/jaegertracing/jaeger v1.43.0/go.mod h1:WrNI6yRNftQh27cWrk4IU1/W7EIzm2MxNVkVGBI0fEw=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -186,8 +186,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
-github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
-github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
+github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
+github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/jaeger-influxdb/internal/queries.go
+++ b/jaeger-influxdb/internal/queries.go
@@ -18,6 +18,9 @@ func traceIDToString(traceID model.TraceID) string {
 }
 
 func queryGetAllWhereTraceID(table string, traceIDs ...model.TraceID) string {
+	if len(traceIDs) == 0 {
+		return fmt.Sprintf(`SELECT * FROM %s WHERE false`, table)
+	}
 	traceIDStrings := make([]string, len(traceIDs))
 	for i, traceID := range traceIDs {
 		traceIDStrings[i] = traceIDToString(traceID)


### PR DESCRIPTION
closes #204

Also resolves concern about SQL query: https://github.com/influxdata/influxdb-observability/pull/207#discussion_r1149811973