### PR TITLE
chore(dependabot): disable version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,22 @@ updates:
     schedule:
       day: "tuesday"
       interval: "weekly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "gomod"
     directory: "/influx2otel"
     schedule:
       day: "tuesday"
       interval: "weekly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "gomod"
     directory: "/jaeger-influxdb"
     schedule:
       day: "tuesday"
       interval: "weekly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "gomod"
     directory: "/otel2influx"
     schedule:
       day: "tuesday"
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
According to [the docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file):
> If you only require security updates and want to exclude version updates, you can set open-pull-requests-limit to 0 in order to prevent version updates for a given package-ecosystem.