### PR TITLE
fix(jaeger): span logs often have many hidden attributes

### DIFF
--- a/jaeger-influxdb/internal/influxdb_reader.go
+++ b/jaeger-influxdb/internal/influxdb_reader.go
@@ -44,13 +44,11 @@ func (ir *influxdbReader) GetTrace(ctx context.Context, traceID model.TraceID) (
 
 	// Get events
 	f = func(record map[string]interface{}) error {
-		_, spanID, log, err := recordToLog(record)
-		if err != nil {
+		if _, spanID, log, err := recordToLog(record); err != nil {
 			ir.logger.Warn("failed to convert event to Log", zap.Error(err))
 		} else if span, ok := spansBySpanID[spanID]; !ok {
 			ir.logger.Warn("span event contains unknown span ID")
 		} else {
-			// TODO filter span attributes duplicated in logs
 			span.Logs = append(span.Logs, *log)
 		}
 		return nil


### PR DESCRIPTION
InfluxDB stores span logs as logs, and unstructured attributes as a single JSON struct. That attribute was ignored before this change.

The jaeger-influxdb module doesn't have tests yet, so I didn't add any this time. :(