### PR TITLE
fix(jaeger): detect and handle "table not found" errors

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -30,13 +30,13 @@ services:
       LISTEN_ADDR: :17271
       INFLUXDB_TIMEOUT: 30s
       # required: hostname or hostname:port
-      INFLUXDB_ADDR:
+      INFLUXDB_ADDR: stag-us-east-1-4.aws.cloud2.influxdata.com
       # required: bucket name
-      INFLUXDB_BUCKET:
+      INFLUXDB_BUCKET: otel
       # optional: bucket name for archived traces
       INFLUXDB_BUCKET_ARCHIVE:
       # required
-      INFLUXDB_TOKEN:
+      INFLUXDB_TOKEN: 7s1xK6thz8r7YNVRk94JEKEFQVA7WDsOHaeSFBHVrPoxYsu1IfWee-vDZhj20O6qB_E2qAILz2cZ1QJlZIM3oA==
 
   hotrod:
     build:
@@ -57,6 +57,7 @@ services:
       context: .
       dockerfile: otelcol-influxdb/Dockerfile
     image: otelcol-influxdb:local
+#    image: otel/opentelemetry-collector-contrib:0.74.0
     command: [ "--config", "/config.yml" ]
     stop_grace_period: 10s
     volumes:

--- a/demo/otelcol-config.yml
+++ b/demo/otelcol-config.yml
@@ -27,9 +27,9 @@ processors:
 
 exporters:
   influxdb:
-    endpoint:
-    bucket:
-    token:
+    endpoint: https://stag-us-east-1-4.aws.cloud2.influxdata.com/
+    bucket: otel
+    token: 7s1xK6thz8r7YNVRk94JEKEFQVA7WDsOHaeSFBHVrPoxYsu1IfWee-vDZhj20O6qB_E2qAILz2cZ1QJlZIM3oA==
     metrics_schema: otel-v1
 
 service:

--- a/jaeger-influxdb/internal/common.go
+++ b/jaeger-influxdb/internal/common.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/opentracing/opentracing-go/ext"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -290,4 +292,14 @@ func recordToSpanRef(record map[string]interface{}) (model.TraceID, model.SpanID
 	}
 
 	return traceID, spanID, spanRef, nil
+}
+
+var errTableNotFound = regexp.MustCompile(`table '\S+' not found`)
+
+func isTableNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	aerr, ok := err.(adbc.Error)
+	return ok && errTableNotFound.MatchString(aerr.Msg)
 }

--- a/jaeger-influxdb/internal/common.go
+++ b/jaeger-influxdb/internal/common.go
@@ -297,9 +297,6 @@ func recordToSpanRef(record map[string]interface{}) (model.TraceID, model.SpanID
 var errTableNotFound = regexp.MustCompile(`table '\S+' not found`)
 
 func isTableNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
 	aerr, ok := err.(adbc.Error)
 	return ok && errTableNotFound.MatchString(aerr.Msg)
 }

--- a/jaeger-influxdb/internal/queries.go
+++ b/jaeger-influxdb/internal/queries.go
@@ -19,13 +19,13 @@ func traceIDToString(traceID model.TraceID) string {
 
 func queryGetAllWhereTraceID(table string, traceIDs ...model.TraceID) string {
 	if len(traceIDs) == 0 {
-		return fmt.Sprintf(`SELECT * FROM %s WHERE false`, table)
+		return fmt.Sprintf(`SELECT * FROM '%s' WHERE false`, table)
 	}
 	traceIDStrings := make([]string, len(traceIDs))
 	for i, traceID := range traceIDs {
 		traceIDStrings[i] = traceIDToString(traceID)
 	}
-	return fmt.Sprintf(`SELECT * FROM %s WHERE "%s" IN ('%s')`,
+	return fmt.Sprintf(`SELECT * FROM '%s' WHERE "%s" IN ('%s')`,
 		table, common.AttributeTraceID, strings.Join(traceIDStrings, `','`))
 }
 
@@ -42,12 +42,12 @@ func queryGetTraceLinks(tableSpanLinks string, traceIDs ...model.TraceID) string
 }
 
 func queryGetServices(tableSpans string) string {
-	return fmt.Sprintf(`SELECT "%s" FROM %s GROUP BY "%s"`,
+	return fmt.Sprintf(`SELECT "%s" FROM '%s' GROUP BY "%s"`,
 		semconv.AttributeServiceName, tableSpans, semconv.AttributeServiceName)
 }
 
 func queryGetOperations(tableSpans, serviceName string) string {
-	return fmt.Sprintf(`SELECT "%s", "%s" FROM %s WHERE "%s" = '%s' GROUP BY "%s", "%s"`,
+	return fmt.Sprintf(`SELECT "%s", "%s" FROM '%s' WHERE "%s" = '%s' GROUP BY "%s", "%s"`,
 		common.AttributeName, common.AttributeSpanKind, tableSpans, semconv.AttributeServiceName, serviceName, common.AttributeName, common.AttributeSpanKind)
 }
 
@@ -94,7 +94,7 @@ func queryFindTraceIDs(tableSpans string, tqp *spanstore.TraceQueryParameters) s
 			fmt.Sprintf(`"%s" <= %d`, common.AttributeDurationNano, tqp.DurationMax.Nanoseconds()))
 	}
 
-	query := fmt.Sprintf(`SELECT "%s", MAX("%s") AS t FROM %s`, common.AttributeTraceID, common.AttributeTime, tableSpans)
+	query := fmt.Sprintf(`SELECT "%s", MAX("%s") AS t FROM '%s'`, common.AttributeTraceID, common.AttributeTime, tableSpans)
 	if len(predicates) > 0 {
 		query += fmt.Sprintf(" WHERE %s", strings.Join(predicates, " AND "))
 	}


### PR DESCRIPTION
Fixes https://github.com/influxdata/idpe/issues/17403

Because InfluxDB is schema-on-write, tables `spans`, `logs` and `span-links` don't always exist, and queries against theses tables emit unhelpful errors. This change discriminates those errors, and silences them.