### PR TITLE
feat(jaeger-influxdb): forgive and handle schema://host:port

### DIFF
--- a/jaeger-influxdb/go.mod
+++ b/jaeger-influxdb/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
+	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0011
 	go.opentelemetry.io/collector/semconv v0.76.1
 	go.uber.org/multierr v1.11.0
@@ -24,6 +25,7 @@ require (
 	github.com/apache/arrow/go/v12 v12.0.0-20230307201612-6fdf1e520a76 // indirect
 	github.com/apache/thrift v0.18.1 // indirect
 	github.com/bluele/gcache v0.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect

--- a/jaeger-influxdb/go.sum
+++ b/jaeger-influxdb/go.sum
@@ -268,6 +268,7 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=

--- a/jaeger-influxdb/internal/influxdb_test.go
+++ b/jaeger-influxdb/internal/influxdb_test.go
@@ -1,0 +1,71 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestComposeHostPortFromAddr(t *testing.T) {
+	logger := zap.NewNop()
+
+	for _, testCase := range []struct {
+		influxdbAddr  string
+		disableTLS    bool
+		expectedValue string
+		expectError   bool
+	}{
+		{"host.tld:80", false, "host.tld:80", false},
+		{"host.tld:80", true, "host.tld:80", false},
+		{"host:80", false, "host:80", false},
+		{"host:80", true, "host:80", false},
+		{"host.tld", false, "host.tld:443", false},
+		{"host.tld", true, "host.tld:443", false},
+		{"host", false, "host:443", false},
+		{"host", true, "host:443", false},
+		{"http://host:80", true, "host:80", false},
+		{"http://host", true, "host:443", false},
+		{"http://host:", true, "host:443", false},
+		{"grpc://host:80", true, "host:80", false},
+		{"grpc+tcp://host:80", true, "host:80", false},
+		{"https://host:80", false, "host:80", false},
+		{"https://host", false, "host:443", false},
+		{"https://host:", false, "host:443", false},
+		{"grpc+tls://host:80", false, "host:80", false},
+
+		{":80", false, "", true},
+		{":80", true, "", true},
+		{"host:", false, "", true},
+		{"host:", true, "", true},
+		{":", false, "", true},
+		{":", true, "", true},
+		{"", false, "", true},
+		{"", true, "", true},
+		{"://", true, "", true},
+		{"://", false, "", true},
+		{"//", true, "", true},
+		{"//", false, "", true},
+		{"http://host", false, "", true},
+		{"http://:80", true, "", true},
+		{"http://:", true, "", true},
+		{"http://", true, "", true},
+		{"https://host", true, "", true},
+		{"https://:80", false, "", true},
+		{"https://:", false, "", true},
+		{"https://", false, "", true},
+	} {
+		t.Run(fmt.Sprintf("%s--%v", strings.ReplaceAll(testCase.influxdbAddr, "://", "_"), testCase.disableTLS), func(t *testing.T) {
+			testCase := testCase
+			actualValue, actualErr := composeHostPortFromAddr(logger, testCase.influxdbAddr, testCase.disableTLS)
+			assert.Equal(t, testCase.expectedValue, actualValue)
+			if testCase.expectError {
+				assert.Error(t, actualErr)
+			} else {
+				assert.NoError(t, actualErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This affects flag --influxdb-addr / env var INFLUXDB_ADDR. Because the demo requires an HTTP URL for write (otelcol), and a gRPC host:port for query (jaeger-influxdb), let's be flexible with the jaeger-influxdb constraints by allowing prefixes http://, https://, grpc://, grpc+tcp://, grpc+tls://.

Accepting the HTTP prefixes is "forgiving". Accepting the gRPC prefixes is treated as "normal" handling, just like host:port.

I've added unit tests this time. :) Also, tested with the Docker Compose demo.