### PR TITLE
feat(otel2influx): Adds support for DELTA temporality metrics

### DIFF
--- a/otel2influx/README.md
+++ b/otel2influx/README.md
@@ -66,8 +66,6 @@ For example:
 - `Metric.unit` is ignored
 - `Metric` values are assigned field keys `gauge`, `counter`, `count`, `sum`, `inf`
   - Metric conversion follows Prometheus conventions for compatibility
-- `Metric` instances with aggregation temporality type `DELTA` are dropped
-  - The Prometheus OpenTelemetry exporter also drops these
 - `LogRecord.flags` is ignored
   - This is an enum with no values defines yet
 

--- a/otel2influx/metrics_telegraf_prometheus_v1.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1.go
@@ -96,9 +96,6 @@ func (c *metricWriterTelegrafPrometheusV1) writeGauge(ctx context.Context, resou
 }
 
 func (c *metricWriterTelegrafPrometheusV1) writeGaugeFromSum(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, sum pmetric.Sum, batch InfluxWriterBatch) error {
-	if sum.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
-		return fmt.Errorf("unsupported sum (as gauge) aggregation temporality %q", sum.AggregationTemporality())
-	}
 
 	for i := 0; i < sum.DataPoints().Len(); i++ {
 		dataPoint := sum.DataPoints().At(i)
@@ -127,9 +124,6 @@ func (c *metricWriterTelegrafPrometheusV1) writeGaugeFromSum(ctx context.Context
 }
 
 func (c *metricWriterTelegrafPrometheusV1) writeSum(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, sum pmetric.Sum, batch InfluxWriterBatch) error {
-	if sum.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
-		return fmt.Errorf("unsupported sum aggregation temporality %q", sum.AggregationTemporality())
-	}
 
 	for i := 0; i < sum.DataPoints().Len(); i++ {
 		dataPoint := sum.DataPoints().At(i)
@@ -158,9 +152,6 @@ func (c *metricWriterTelegrafPrometheusV1) writeSum(ctx context.Context, resourc
 }
 
 func (c *metricWriterTelegrafPrometheusV1) writeHistogram(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, histogram pmetric.Histogram, batch InfluxWriterBatch) error {
-	if histogram.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
-		return fmt.Errorf("unsupported histogram aggregation temporality %q", histogram.AggregationTemporality())
-	}
 
 	for i := 0; i < histogram.DataPoints().Len(); i++ {
 		dataPoint := histogram.DataPoints().At(i)

--- a/otel2influx/metrics_telegraf_prometheus_v1_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1_test.go
@@ -80,259 +80,271 @@ func TestWriteMetric_v1_gauge(t *testing.T) {
 }
 
 func TestWriteMetric_v1_gaugeFromSum(t *testing.T) {
-	w := new(MockInfluxWriter)
-	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV1)
-	require.NoError(t, err)
+	temporalities := [2]pmetric.AggregationTemporality{pmetric.AggregationTemporalityCumulative, pmetric.AggregationTemporalityDelta}
+	for _, temporality := range temporalities {
+		w := new(MockInfluxWriter)
+		c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV1)
+		require.NoError(t, err)
 
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr("container.name", "42")
-	ilMetrics := rm.ScopeMetrics().AppendEmpty()
-	ilMetrics.Scope().SetName("My Library")
-	ilMetrics.Scope().SetVersion("latest")
-	m := ilMetrics.Metrics().AppendEmpty()
-	m.SetName("cache_age_seconds")
-	m.SetDescription("Age in seconds of the current cache")
-	m.SetEmptySum()
-	m.Sum().SetIsMonotonic(false)
-	m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dp := m.Sum().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("engine_id", 0)
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetDoubleValue(23.9)
-	dp = m.Sum().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("engine_id", 1)
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetDoubleValue(11.9)
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("container.name", "42")
+		ilMetrics := rm.ScopeMetrics().AppendEmpty()
+		ilMetrics.Scope().SetName("My Library")
+		ilMetrics.Scope().SetVersion("latest")
+		m := ilMetrics.Metrics().AppendEmpty()
+		m.SetName("cache_age_seconds")
+		m.SetDescription("Age in seconds of the current cache")
+		m.SetEmptySum()
+		m.Sum().SetIsMonotonic(false)
+		m.Sum().SetAggregationTemporality(temporality)
+		dp := m.Sum().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("engine_id", 0)
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetDoubleValue(23.9)
+		dp = m.Sum().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("engine_id", 1)
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetDoubleValue(11.9)
 
-	err = c.WriteMetrics(context.Background(), metrics)
-	require.NoError(t, err)
+		err = c.WriteMetrics(context.Background(), metrics)
+		require.NoError(t, err)
 
-	expected := []mockPoint{
-		{
-			measurement: "cache_age_seconds",
-			tags: map[string]string{
-				"container.name":       "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"engine_id":            "0",
+		expected := []mockPoint{
+			{
+				measurement: "cache_age_seconds",
+				tags: map[string]string{
+					"container.name":       "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"engine_id":            "0",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"gauge":                           float64(23.9),
+				},
+				ts:    time.Unix(0, 1395066363000000123).UTC(),
+				vType: common.InfluxMetricValueTypeGauge,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"gauge":                           float64(23.9),
+			{
+				measurement: "cache_age_seconds",
+				tags: map[string]string{
+					"container.name":       "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"engine_id":            "1",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"gauge":                           float64(11.9),
+				},
+				ts:    time.Unix(0, 1395066363000000123).UTC(),
+				vType: common.InfluxMetricValueTypeGauge,
 			},
-			ts:    time.Unix(0, 1395066363000000123).UTC(),
-			vType: common.InfluxMetricValueTypeGauge,
-		},
-		{
-			measurement: "cache_age_seconds",
-			tags: map[string]string{
-				"container.name":       "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"engine_id":            "1",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"gauge":                           float64(11.9),
-			},
-			ts:    time.Unix(0, 1395066363000000123).UTC(),
-			vType: common.InfluxMetricValueTypeGauge,
-		},
+		}
+
+		assert.Equal(t, expected, w.points)
 	}
-
-	assert.Equal(t, expected, w.points)
 }
 
 func TestWriteMetric_v1_sum(t *testing.T) {
-	w := new(MockInfluxWriter)
-	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV1)
-	require.NoError(t, err)
+	temporalities := [2]pmetric.AggregationTemporality{pmetric.AggregationTemporalityCumulative, pmetric.AggregationTemporalityDelta}
 
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr("container.name", "42")
-	ilMetrics := rm.ScopeMetrics().AppendEmpty()
-	ilMetrics.Scope().SetName("My Library")
-	ilMetrics.Scope().SetVersion("latest")
-	m := ilMetrics.Metrics().AppendEmpty()
-	m.SetName("http_requests_total")
-	m.SetDescription("The total number of HTTP requests")
-	m.SetEmptySum()
-	m.Sum().SetIsMonotonic(true)
-	m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dp := m.Sum().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("code", 200)
-	dp.Attributes().PutStr("method", "post")
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetDoubleValue(1027)
-	dp = m.Sum().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("code", 400)
-	dp.Attributes().PutStr("method", "post")
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetDoubleValue(3)
+	for _, temporality := range temporalities {
+		w := new(MockInfluxWriter)
+		c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV1)
+		require.NoError(t, err)
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("container.name", "42")
+		ilMetrics := rm.ScopeMetrics().AppendEmpty()
+		ilMetrics.Scope().SetName("My Library")
+		ilMetrics.Scope().SetVersion("latest")
+		m := ilMetrics.Metrics().AppendEmpty()
+		m.SetName("http_requests_total")
+		m.SetDescription("The total number of HTTP requests")
+		m.SetEmptySum()
+		m.Sum().SetIsMonotonic(true)
+		m.Sum().SetAggregationTemporality(temporality)
+		dp := m.Sum().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("code", 200)
+		dp.Attributes().PutStr("method", "post")
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetDoubleValue(1027)
+		dp = m.Sum().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("code", 400)
+		dp.Attributes().PutStr("method", "post")
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetDoubleValue(3)
 
-	err = c.WriteMetrics(context.Background(), metrics)
-	require.NoError(t, err)
+		err = c.WriteMetrics(context.Background(), metrics)
+		require.NoError(t, err)
 
-	expected := []mockPoint{
-		{
-			measurement: "http_requests_total",
-			tags: map[string]string{
-				"container.name":       "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
+		expected := []mockPoint{
+			{
+				measurement: "http_requests_total",
+				tags: map[string]string{
+					"container.name":       "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"counter":                         float64(1027),
+				},
+				ts:    time.Unix(0, 1395066363000000123).UTC(),
+				vType: common.InfluxMetricValueTypeSum,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"counter":                         float64(1027),
+			{
+				measurement: "http_requests_total",
+				tags: map[string]string{
+					"container.name":       "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "400",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"counter":                         float64(3),
+				},
+				ts:    time.Unix(0, 1395066363000000123).UTC(),
+				vType: common.InfluxMetricValueTypeSum,
 			},
-			ts:    time.Unix(0, 1395066363000000123).UTC(),
-			vType: common.InfluxMetricValueTypeSum,
-		},
-		{
-			measurement: "http_requests_total",
-			tags: map[string]string{
-				"container.name":       "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "400",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"counter":                         float64(3),
-			},
-			ts:    time.Unix(0, 1395066363000000123).UTC(),
-			vType: common.InfluxMetricValueTypeSum,
-		},
+		}
+
+		assert.Equal(t, expected, w.points)
 	}
-
-	assert.Equal(t, expected, w.points)
 }
 
 func TestWriteMetric_v1_histogram(t *testing.T) {
-	w := new(MockInfluxWriter)
-	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV1)
-	require.NoError(t, err)
+	temporalities := [2]pmetric.AggregationTemporality{pmetric.AggregationTemporalityCumulative, pmetric.AggregationTemporalityDelta}
+	for _, temporality := range temporalities {
+		w := new(MockInfluxWriter)
+		c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV1)
+		require.NoError(t, err)
 
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr("container.name", "42")
-	ilMetrics := rm.ScopeMetrics().AppendEmpty()
-	ilMetrics.Scope().SetName("My Library")
-	ilMetrics.Scope().SetVersion("latest")
-	m := ilMetrics.Metrics().AppendEmpty()
-	m.SetName("http_request_duration_seconds")
-	m.SetEmptyHistogram()
-	m.SetDescription("A histogram of the request duration")
-	m.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dp := m.Histogram().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("code", 200)
-	dp.Attributes().PutStr("method", "post")
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetCount(144320)
-	dp.SetSum(53423)
-	dp.SetMin(0)
-	dp.SetMax(100)
-	dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
-	dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("container.name", "42")
+		ilMetrics := rm.ScopeMetrics().AppendEmpty()
+		ilMetrics.Scope().SetName("My Library")
+		ilMetrics.Scope().SetVersion("latest")
+		m := ilMetrics.Metrics().AppendEmpty()
+		m.SetName("http_request_duration_seconds")
+		m.SetEmptyHistogram()
+		m.SetDescription("A histogram of the request duration")
+		m.Histogram().SetAggregationTemporality(temporality)
+		dp := m.Histogram().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("code", 200)
+		dp.Attributes().PutStr("method", "post")
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetCount(144320)
+		dp.SetSum(53423)
+		dp.SetMin(0)
+		dp.SetMax(100)
+		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
+		dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
 
-	err = c.WriteMetrics(context.Background(), metrics)
-	require.NoError(t, err)
+		err = c.WriteMetrics(context.Background(), metrics)
+		require.NoError(t, err)
 
-	expected := []mockPoint{
-		{
-			measurement: "http_request_duration_seconds",
-			tags: map[string]string{
-				"container.name":       "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
+		expected := []mockPoint{
+			{
+				measurement: "http_request_duration_seconds",
+				tags: map[string]string{
+					"container.name":       "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"count":                           float64(144320),
+					"sum":                             float64(53423),
+					"0.05":                            float64(24054),
+					"0.1":                             float64(33444),
+					"0.2":                             float64(100392),
+					"0.5":                             float64(129389),
+					"1":                               float64(133988),
+					"min":                             float64(0),
+					"max":                             float64(100),
+				},
+				ts:    time.Unix(0, 1395066363000000123).UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"count":                           float64(144320),
-				"sum":                             float64(53423),
-				"0.05":                            float64(24054),
-				"0.1":                             float64(33444),
-				"0.2":                             float64(100392),
-				"0.5":                             float64(129389),
-				"1":                               float64(133988),
-				"min":                             float64(0),
-				"max":                             float64(100),
-			},
-			ts:    time.Unix(0, 1395066363000000123).UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
+		}
+
+		assert.Equal(t, expected, w.points)
 	}
-
-	assert.Equal(t, expected, w.points)
 }
 
 func TestWriteMetric_v1_histogram_missingInfinityBucket(t *testing.T) {
-	w := new(MockInfluxWriter)
-	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV1)
-	require.NoError(t, err)
+	temporalities := [2]pmetric.AggregationTemporality{pmetric.AggregationTemporalityCumulative, pmetric.AggregationTemporalityDelta}
+	for _, temporality := range temporalities {
+		w := new(MockInfluxWriter)
+		c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV1)
+		require.NoError(t, err)
 
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr("container.name", "42")
-	ilMetrics := rm.ScopeMetrics().AppendEmpty()
-	ilMetrics.Scope().SetName("My Library")
-	ilMetrics.Scope().SetVersion("latest")
-	m := ilMetrics.Metrics().AppendEmpty()
-	m.SetName("http_request_duration_seconds")
-	m.SetEmptyHistogram()
-	m.SetDescription("A histogram of the request duration")
-	m.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dp := m.Histogram().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("code", 200)
-	dp.Attributes().PutStr("method", "post")
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetCount(144320)
-	dp.SetSum(53423)
-	dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
-	dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("container.name", "42")
+		ilMetrics := rm.ScopeMetrics().AppendEmpty()
+		ilMetrics.Scope().SetName("My Library")
+		ilMetrics.Scope().SetVersion("latest")
+		m := ilMetrics.Metrics().AppendEmpty()
+		m.SetName("http_request_duration_seconds")
+		m.SetEmptyHistogram()
+		m.SetDescription("A histogram of the request duration")
+		m.Histogram().SetAggregationTemporality(temporality)
+		dp := m.Histogram().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("code", 200)
+		dp.Attributes().PutStr("method", "post")
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetCount(144320)
+		dp.SetSum(53423)
+		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
+		dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
 
-	err = c.WriteMetrics(context.Background(), metrics)
-	require.NoError(t, err)
+		err = c.WriteMetrics(context.Background(), metrics)
+		require.NoError(t, err)
 
-	expected := []mockPoint{
-		{
-			measurement: "http_request_duration_seconds",
-			tags: map[string]string{
-				"container.name":       "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
+		expected := []mockPoint{
+			{
+				measurement: "http_request_duration_seconds",
+				tags: map[string]string{
+					"container.name":       "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"count":                           float64(144320),
+					"sum":                             float64(53423),
+					"0.05":                            float64(24054),
+					"0.1":                             float64(33444),
+					"0.2":                             float64(100392),
+					"0.5":                             float64(129389),
+					"1":                               float64(133988),
+				},
+				ts:    time.Unix(0, 1395066363000000123).UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"count":                           float64(144320),
-				"sum":                             float64(53423),
-				"0.05":                            float64(24054),
-				"0.1":                             float64(33444),
-				"0.2":                             float64(100392),
-				"0.5":                             float64(129389),
-				"1":                               float64(133988),
-			},
-			ts:    time.Unix(0, 1395066363000000123).UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
+		}
+
+		assert.Equal(t, expected, w.points)
 	}
-
-	assert.Equal(t, expected, w.points)
 }
 
 func TestWriteMetric_v1_summary(t *testing.T) {

--- a/otel2influx/metrics_telegraf_prometheus_v2.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2.go
@@ -96,9 +96,6 @@ func (c *metricWriterTelegrafPrometheusV2) writeGauge(ctx context.Context, resou
 }
 
 func (c *metricWriterTelegrafPrometheusV2) writeGaugeFromSum(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, sum pmetric.Sum, batch InfluxWriterBatch) error {
-	if sum.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
-		return fmt.Errorf("unsupported sum (as gauge) aggregation temporality %q", sum.AggregationTemporality())
-	}
 
 	for i := 0; i < sum.DataPoints().Len(); i++ {
 		dataPoint := sum.DataPoints().At(i)
@@ -127,9 +124,6 @@ func (c *metricWriterTelegrafPrometheusV2) writeGaugeFromSum(ctx context.Context
 }
 
 func (c *metricWriterTelegrafPrometheusV2) writeSum(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, sum pmetric.Sum, batch InfluxWriterBatch) error {
-	if sum.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
-		return fmt.Errorf("unsupported sum aggregation temporality %q", sum.AggregationTemporality())
-	}
 
 	for i := 0; i < sum.DataPoints().Len(); i++ {
 		dataPoint := sum.DataPoints().At(i)
@@ -158,9 +152,6 @@ func (c *metricWriterTelegrafPrometheusV2) writeSum(ctx context.Context, resourc
 }
 
 func (c *metricWriterTelegrafPrometheusV2) writeHistogram(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, histogram pmetric.Histogram, batch InfluxWriterBatch) error {
-	if histogram.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
-		return fmt.Errorf("unsupported histogram aggregation temporality %q", histogram.AggregationTemporality())
-	}
 
 	for i := 0; i < histogram.DataPoints().Len(); i++ {
 		dataPoint := histogram.DataPoints().At(i)

--- a/otel2influx/metrics_telegraf_prometheus_v2_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2_test.go
@@ -78,419 +78,431 @@ func TestWriteMetric_v2_gauge(t *testing.T) {
 }
 
 func TestWriteMetric_v2_gaugeFromSum(t *testing.T) {
-	w := new(MockInfluxWriter)
-	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV2)
-	require.NoError(t, err)
+	temporalities := [2]pmetric.AggregationTemporality{pmetric.AggregationTemporalityCumulative, pmetric.AggregationTemporalityDelta}
+	for _, temporality := range temporalities {
+		w := new(MockInfluxWriter)
+		c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV2)
+		require.NoError(t, err)
 
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr("node", "42")
-	ilMetrics := rm.ScopeMetrics().AppendEmpty()
-	ilMetrics.Scope().SetName("My Library")
-	ilMetrics.Scope().SetVersion("latest")
-	m := ilMetrics.Metrics().AppendEmpty()
-	m.SetName("cache_age_seconds")
-	m.SetDescription("Age in seconds of the current cache")
-	m.SetEmptySum()
-	m.Sum().SetIsMonotonic(false)
-	m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dp := m.Sum().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("engine_id", 0)
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetDoubleValue(23.9)
-	dp = m.Sum().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("engine_id", 1)
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetDoubleValue(11.9)
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("node", "42")
+		ilMetrics := rm.ScopeMetrics().AppendEmpty()
+		ilMetrics.Scope().SetName("My Library")
+		ilMetrics.Scope().SetVersion("latest")
+		m := ilMetrics.Metrics().AppendEmpty()
+		m.SetName("cache_age_seconds")
+		m.SetDescription("Age in seconds of the current cache")
+		m.SetEmptySum()
+		m.Sum().SetIsMonotonic(false)
+		m.Sum().SetAggregationTemporality(temporality)
+		dp := m.Sum().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("engine_id", 0)
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetDoubleValue(23.9)
+		dp = m.Sum().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("engine_id", 1)
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetDoubleValue(11.9)
 
-	err = c.WriteMetrics(context.Background(), metrics)
-	require.NoError(t, err)
+		err = c.WriteMetrics(context.Background(), metrics)
+		require.NoError(t, err)
 
-	expected := []mockPoint{
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"engine_id":            "0",
+		expected := []mockPoint{
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"engine_id":            "0",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"cache_age_seconds":               float64(23.9),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeGauge,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"cache_age_seconds":               float64(23.9),
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"engine_id":            "1",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"cache_age_seconds":               float64(11.9),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeGauge,
 			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeGauge,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"engine_id":            "1",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"cache_age_seconds":               float64(11.9),
-			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeGauge,
-		},
+		}
+
+		assert.EqualValues(t, expected, w.points)
 	}
-
-	assert.EqualValues(t, expected, w.points)
 }
 
 func TestWriteMetric_v2_sum(t *testing.T) {
-	w := new(MockInfluxWriter)
-	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV2)
-	require.NoError(t, err)
+	temporalities := [2]pmetric.AggregationTemporality{pmetric.AggregationTemporalityCumulative, pmetric.AggregationTemporalityDelta}
+	for _, temporality := range temporalities {
+		w := new(MockInfluxWriter)
+		c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV2)
+		require.NoError(t, err)
 
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr("node", "42")
-	ilMetrics := rm.ScopeMetrics().AppendEmpty()
-	ilMetrics.Scope().SetName("My Library")
-	ilMetrics.Scope().SetVersion("latest")
-	m := ilMetrics.Metrics().AppendEmpty()
-	m.SetName("http_requests_total")
-	m.SetDescription("The total number of HTTP requests")
-	m.SetEmptySum()
-	m.Sum().SetIsMonotonic(true)
-	m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dp := m.Sum().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("code", 200)
-	dp.Attributes().PutStr("method", "post")
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetDoubleValue(1027)
-	dp = m.Sum().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("code", 400)
-	dp.Attributes().PutStr("method", "post")
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetDoubleValue(3)
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("node", "42")
+		ilMetrics := rm.ScopeMetrics().AppendEmpty()
+		ilMetrics.Scope().SetName("My Library")
+		ilMetrics.Scope().SetVersion("latest")
+		m := ilMetrics.Metrics().AppendEmpty()
+		m.SetName("http_requests_total")
+		m.SetDescription("The total number of HTTP requests")
+		m.SetEmptySum()
+		m.Sum().SetIsMonotonic(true)
+		m.Sum().SetAggregationTemporality(temporality)
+		dp := m.Sum().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("code", 200)
+		dp.Attributes().PutStr("method", "post")
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetDoubleValue(1027)
+		dp = m.Sum().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("code", 400)
+		dp.Attributes().PutStr("method", "post")
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetDoubleValue(3)
 
-	err = c.WriteMetrics(context.Background(), metrics)
-	require.NoError(t, err)
+		err = c.WriteMetrics(context.Background(), metrics)
+		require.NoError(t, err)
 
-	expected := []mockPoint{
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
+		expected := []mockPoint{
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"http_requests_total":             float64(1027),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeSum,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"http_requests_total":             float64(1027),
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "400",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano: int64(startTimestamp),
+					"http_requests_total":             float64(3),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeSum,
 			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeSum,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "400",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano: int64(startTimestamp),
-				"http_requests_total":             float64(3),
-			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeSum,
-		},
+		}
+
+		assert.EqualValues(t, expected, w.points)
 	}
-
-	assert.EqualValues(t, expected, w.points)
 }
 
 func TestWriteMetric_v2_histogram(t *testing.T) {
-	w := new(MockInfluxWriter)
-	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV2)
-	require.NoError(t, err)
+	temporalities := [2]pmetric.AggregationTemporality{pmetric.AggregationTemporalityCumulative, pmetric.AggregationTemporalityDelta}
+	for _, temporality := range temporalities {
+		w := new(MockInfluxWriter)
+		c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV2)
+		require.NoError(t, err)
 
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr("node", "42")
-	ilMetrics := rm.ScopeMetrics().AppendEmpty()
-	ilMetrics.Scope().SetName("My Library")
-	ilMetrics.Scope().SetVersion("latest")
-	m := ilMetrics.Metrics().AppendEmpty()
-	m.SetName("http_request_duration_seconds")
-	m.SetEmptyHistogram()
-	m.SetDescription("A histogram of the request duration")
-	m.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dp := m.Histogram().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("code", 200)
-	dp.Attributes().PutStr("method", "post")
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetCount(144320)
-	dp.SetSum(53423)
-	dp.SetMin(0)
-	dp.SetMax(100)
-	dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
-	dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("node", "42")
+		ilMetrics := rm.ScopeMetrics().AppendEmpty()
+		ilMetrics.Scope().SetName("My Library")
+		ilMetrics.Scope().SetVersion("latest")
+		m := ilMetrics.Metrics().AppendEmpty()
+		m.SetName("http_request_duration_seconds")
+		m.SetEmptyHistogram()
+		m.SetDescription("A histogram of the request duration")
+		m.Histogram().SetAggregationTemporality(temporality)
+		dp := m.Histogram().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("code", 200)
+		dp.Attributes().PutStr("method", "post")
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetCount(144320)
+		dp.SetSum(53423)
+		dp.SetMin(0)
+		dp.SetMax(100)
+		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
+		dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
 
-	err = c.WriteMetrics(context.Background(), metrics)
-	require.NoError(t, err)
+		err = c.WriteMetrics(context.Background(), metrics)
+		require.NoError(t, err)
 
-	expected := []mockPoint{
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
+		expected := []mockPoint{
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:     int64(startTimestamp),
+					"http_request_duration_seconds_count": float64(144320),
+					"http_request_duration_seconds_sum":   float64(53423),
+					"http_request_duration_seconds_min":   float64(0),
+					"http_request_duration_seconds_max":   float64(100),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:     int64(startTimestamp),
-				"http_request_duration_seconds_count": float64(144320),
-				"http_request_duration_seconds_sum":   float64(53423),
-				"http_request_duration_seconds_min":   float64(0),
-				"http_request_duration_seconds_max":   float64(100),
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "0.05",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(24054),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "0.05",
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "0.1",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(33444),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(24054),
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "0.2",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(100392),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "0.1",
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "0.5",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(129389),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(33444),
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "1",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(133988),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "0.2",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(100392),
-			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "0.5",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(129389),
-			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "1",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(133988),
-			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
+		}
+
+		assert.Equal(t, expected, w.points)
 	}
-
-	assert.Equal(t, expected, w.points)
 }
 
 func TestWriteMetric_v2_histogram_missingInfinityBucket(t *testing.T) {
-	w := new(MockInfluxWriter)
-	c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV2)
-	require.NoError(t, err)
+	temporalities := [2]pmetric.AggregationTemporality{pmetric.AggregationTemporalityCumulative, pmetric.AggregationTemporalityDelta}
+	for _, temporality := range temporalities {
+		w := new(MockInfluxWriter)
+		c, err := otel2influx.NewOtelMetricsToLineProtocol(new(common.NoopLogger), w, common.MetricsSchemaTelegrafPrometheusV2)
+		require.NoError(t, err)
 
-	metrics := pmetric.NewMetrics()
-	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr("node", "42")
-	ilMetrics := rm.ScopeMetrics().AppendEmpty()
-	ilMetrics.Scope().SetName("My Library")
-	ilMetrics.Scope().SetVersion("latest")
-	m := ilMetrics.Metrics().AppendEmpty()
-	m.SetName("http_request_duration_seconds")
-	m.SetEmptyHistogram()
-	m.SetDescription("A histogram of the request duration")
-	m.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dp := m.Histogram().DataPoints().AppendEmpty()
-	dp.Attributes().PutInt("code", 200)
-	dp.Attributes().PutStr("method", "post")
-	dp.SetStartTimestamp(startTimestamp)
-	dp.SetTimestamp(timestamp)
-	dp.SetCount(144320)
-	dp.SetSum(53423)
-	dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
-	dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
+		metrics := pmetric.NewMetrics()
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("node", "42")
+		ilMetrics := rm.ScopeMetrics().AppendEmpty()
+		ilMetrics.Scope().SetName("My Library")
+		ilMetrics.Scope().SetVersion("latest")
+		m := ilMetrics.Metrics().AppendEmpty()
+		m.SetName("http_request_duration_seconds")
+		m.SetEmptyHistogram()
+		m.SetDescription("A histogram of the request duration")
+		m.Histogram().SetAggregationTemporality(temporality)
+		dp := m.Histogram().DataPoints().AppendEmpty()
+		dp.Attributes().PutInt("code", 200)
+		dp.Attributes().PutStr("method", "post")
+		dp.SetStartTimestamp(startTimestamp)
+		dp.SetTimestamp(timestamp)
+		dp.SetCount(144320)
+		dp.SetSum(53423)
+		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
+		dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
 
-	err = c.WriteMetrics(context.Background(), metrics)
-	require.NoError(t, err)
+		err = c.WriteMetrics(context.Background(), metrics)
+		require.NoError(t, err)
 
-	expected := []mockPoint{
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
+		expected := []mockPoint{
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:     int64(startTimestamp),
+					"http_request_duration_seconds_count": float64(144320),
+					"http_request_duration_seconds_sum":   float64(53423),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:     int64(startTimestamp),
-				"http_request_duration_seconds_count": float64(144320),
-				"http_request_duration_seconds_sum":   float64(53423),
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "0.05",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(24054),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "0.05",
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "0.1",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(33444),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(24054),
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "0.2",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(100392),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "0.1",
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "0.5",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(129389),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(33444),
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "1",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(133988),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
 			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "0.2",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(100392),
-			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "0.5",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(129389),
-			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
-		{
-			measurement: "prometheus",
-			tags: map[string]string{
-				"node":                 "42",
-				"otel.library.name":    "My Library",
-				"otel.library.version": "latest",
-				"method":               "post",
-				"code":                 "200",
-				"le":                   "1",
-			},
-			fields: map[string]interface{}{
-				common.AttributeStartTimeUnixNano:      int64(startTimestamp),
-				"http_request_duration_seconds_bucket": float64(133988),
-			},
-			ts:    timestamp.AsTime().UTC(),
-			vType: common.InfluxMetricValueTypeHistogram,
-		},
+		}
+
+		assert.Equal(t, expected, w.points)
 	}
-
-	assert.Equal(t, expected, w.points)
 }
 
 func TestWriteMetric_v2_summary(t *testing.T) {


### PR DESCRIPTION
Supporting https://github.com/influxdata/influxdb-observability/issues/6