### PR TITLE
chore(otelcol-influxdb): update OpenTelemetry to v0.79.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,21 @@ jobs:
         go install honnef.co/go/tools/cmd/staticcheck@2023.1.3 &&
         cd ${{ matrix.package }} &&
         staticcheck -f stylish ./...
+
+  build-otelcol-influxdb:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "1.20"
+
+    - name: build
+      run: >
+        go install go.opentelemetry.io/collector/cmd/builder@v0.79.0 &&
+        cd otelcol-influxdb &&
+        builder --config build.yml

--- a/otelcol-influxdb/Dockerfile
+++ b/otelcol-influxdb/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   --mount=type=cache,id=influxdb-observability-gocache,sharing=locked,target=/root/.cache/go-build \
   --mount=type=cache,id=influxdb-observability-gomodcache,sharing=locked,target=/go/pkg/mod \
   du -cshx /root/.cache/go-build /go/pkg/mod && \
-  go install go.opentelemetry.io/collector/cmd/builder@v0.78.2 && \
+  go install go.opentelemetry.io/collector/cmd/builder@v0.79.0 && \
   du -cshx /root/.cache/go-build /go/pkg/mod
 
 COPY . /project

--- a/otelcol-influxdb/build.yml
+++ b/otelcol-influxdb/build.yml
@@ -2,44 +2,43 @@ dist:
   name: otelcol-influxdb
   module: github.com/influxdata/influxdb-observability/otelcol-influxdb
   description: OpenTelemetry Collector Distribution built for InfluxDB
-  version: 0.78.0-0.0.0-beta.0
-  otelcol_version: 0.78.2
+  version: 0.79.0-0.0.0-beta.0
+  otelcol_version: 0.79.0
   output_path: ./build
 
 receivers:
-- gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.78.2
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.78.0
+- gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.79.0
 
 exporters:
-- gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.78.2
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter v0.78.0
+- gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter v0.79.0
 
 connectors:
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.78.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.79.0
 
 extensions:
-- gomod: go.opentelemetry.io/collector/extension/ballastextension v0.78.2
-- gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.78.2
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.78.0
+- gomod: go.opentelemetry.io/collector/extension/ballastextension v0.79.0
+- gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.79.0
 
 processors:
-- gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.78.2
-- gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.78.2
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.78.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.78.0
+- gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.79.0
+- gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.79.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.79.0
 
 replaces:
 - github.com/influxdata/influxdb-observability/common => ../../common
 - github.com/influxdata/influxdb-observability/influx2otel => ../../influx2otel
 - github.com/influxdata/influxdb-observability/otel2influx => ../../otel2influx
-- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0
-- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
-- go.opentelemetry.io/otel/sdk/metric => go.opentelemetry.io/otel/sdk/metric v0.39.0
+- github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter v0.0.0-20230608045034-d0fe5f310ca8
+- github.com/influxdata/telegraf => github.com/jacobmarble/telegraf v0.0.0-20230607232722-681953ef7ac2

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -16,6 +16,13 @@ if ! hash staticcheck; then
     exit 1
   fi
 fi
+if ! hash builder; then
+  echo "installing the opentelemetry collector builder"
+  if ! go install go.opentelemetry.io/collector/cmd/builder@v0.79.0; then
+    echo "failed to install the opentelemetry collector builder"
+    exit 1
+  fi
+fi
 
 for package in common influx2otel otel2influx jaeger-influxdb tests-integration; do
   echo checking ${package}
@@ -41,6 +48,12 @@ for package in common influx2otel otel2influx jaeger-influxdb tests-integration;
     fail=1
   fi
 done
+
+echo checking otelcol-influxdb
+cd "${BASEDIR}/otelcol-influxdb"
+if ! builder --config build.yml; then
+  fail=1
+fi
 
 echo
 


### PR DESCRIPTION
Also improves checks.