### PR TITLE
chore(otel2influx): add context to InfluxWriterBatch.EnqueuePoint

### DIFF
--- a/otel2influx/logs.go
+++ b/otel2influx/logs.go
@@ -45,7 +45,7 @@ func (c *OtelLogsToLineProtocol) WriteLogs(ctx context.Context, ld plog.Logs) er
 			ilLogs := resourceLogs.ScopeLogs().At(j)
 			for k := 0; k < ilLogs.LogRecords().Len(); k++ {
 				logRecord := ilLogs.LogRecords().At(k)
-				if err := c.enqueueLogRecord(resourceLogs.Resource(), ilLogs.Scope(), logRecord, batch); err != nil {
+				if err := c.enqueueLogRecord(ctx, resourceLogs.Resource(), ilLogs.Scope(), logRecord, batch); err != nil {
 					return consumererror.NewPermanent(fmt.Errorf("failed to convert OTLP log record to line protocol: %w", err))
 				}
 			}
@@ -54,7 +54,7 @@ func (c *OtelLogsToLineProtocol) WriteLogs(ctx context.Context, ld plog.Logs) er
 	return batch.WriteBatch(ctx)
 }
 
-func (c *OtelLogsToLineProtocol) enqueueLogRecord(resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, logRecord plog.LogRecord, batch InfluxWriterBatch) error {
+func (c *OtelLogsToLineProtocol) enqueueLogRecord(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, logRecord plog.LogRecord, batch InfluxWriterBatch) error {
 	ts := logRecord.Timestamp().AsTime()
 	if ts.IsZero() {
 		// This is a valid condition in OpenTelemetry, but not in InfluxDB.
@@ -108,7 +108,7 @@ func (c *OtelLogsToLineProtocol) enqueueLogRecord(resource pcommon.Resource, ins
 		fields[common.AttributeDroppedAttributesCount] = droppedAttributesCount
 	}
 
-	if err := batch.EnqueuePoint(measurement, tags, fields, ts, common.InfluxMetricValueTypeUntyped); err != nil {
+	if err := batch.EnqueuePoint(ctx, measurement, tags, fields, ts, common.InfluxMetricValueTypeUntyped); err != nil {
 		return fmt.Errorf("failed to write point for int gauge: %w", err)
 	}
 

--- a/otel2influx/metrics.go
+++ b/otel2influx/metrics.go
@@ -26,7 +26,7 @@ func DefaultOtelMetricsToLineProtocolConfig() *OtelMetricsToLineProtocolConfig {
 }
 
 type metricWriter interface {
-	enqueueMetric(resource pcommon.Resource, instrumentationScope pcommon.InstrumentationScope, metric pmetric.Metric, batch InfluxWriterBatch) error
+	enqueueMetric(ctx context.Context, resource pcommon.Resource, instrumentationScope pcommon.InstrumentationScope, metric pmetric.Metric, batch InfluxWriterBatch) error
 }
 
 type OtelMetricsToLineProtocol struct {
@@ -66,7 +66,7 @@ func (c *OtelMetricsToLineProtocol) WriteMetrics(ctx context.Context, md pmetric
 			ilMetrics := resourceMetrics.ScopeMetrics().At(j)
 			for k := 0; k < ilMetrics.Metrics().Len(); k++ {
 				metric := ilMetrics.Metrics().At(k)
-				if err := c.mw.enqueueMetric(resourceMetrics.Resource(), ilMetrics.Scope(), metric, batch); err != nil {
+				if err := c.mw.enqueueMetric(ctx, resourceMetrics.Resource(), ilMetrics.Scope(), metric, batch); err != nil {
 					return consumererror.NewPermanent(fmt.Errorf("failed to convert OTLP metric to line protocol: %w", err))
 				}
 			}

--- a/otel2influx/metrics_telegraf_prometheus_v2.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2.go
@@ -1,6 +1,7 @@
 package otel2influx
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -16,20 +17,20 @@ type metricWriterTelegrafPrometheusV2 struct {
 	logger common.Logger
 }
 
-func (c *metricWriterTelegrafPrometheusV2) enqueueMetric(resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, metric pmetric.Metric, batch InfluxWriterBatch) error {
+func (c *metricWriterTelegrafPrometheusV2) enqueueMetric(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, metric pmetric.Metric, batch InfluxWriterBatch) error {
 	// Ignore metric.Description() and metric.Unit() .
 	switch metric.Type() {
 	case pmetric.MetricTypeGauge:
-		return c.enqueueGauge(resource, instrumentationLibrary, metric.Name(), metric.Gauge(), batch)
+		return c.enqueueGauge(ctx, resource, instrumentationLibrary, metric.Name(), metric.Gauge(), batch)
 	case pmetric.MetricTypeSum:
 		if metric.Sum().IsMonotonic() {
-			return c.enqueueSum(resource, instrumentationLibrary, metric.Name(), metric.Sum(), batch)
+			return c.enqueueSum(ctx, resource, instrumentationLibrary, metric.Name(), metric.Sum(), batch)
 		}
-		return c.enqueueGaugeFromSum(resource, instrumentationLibrary, metric.Name(), metric.Sum(), batch)
+		return c.enqueueGaugeFromSum(ctx, resource, instrumentationLibrary, metric.Name(), metric.Sum(), batch)
 	case pmetric.MetricTypeHistogram:
-		return c.enqueueHistogram(resource, instrumentationLibrary, metric.Name(), metric.Histogram(), batch)
+		return c.enqueueHistogram(ctx, resource, instrumentationLibrary, metric.Name(), metric.Histogram(), batch)
 	case pmetric.MetricTypeSummary:
-		return c.enqueueSummary(resource, instrumentationLibrary, metric.Name(), metric.Summary(), batch)
+		return c.enqueueSummary(ctx, resource, instrumentationLibrary, metric.Name(), metric.Summary(), batch)
 	default:
 		return fmt.Errorf("unknown metric type %q", metric.Type())
 	}
@@ -67,7 +68,7 @@ func (c *metricWriterTelegrafPrometheusV2) initMetricTagsAndTimestamp(resource p
 	return
 }
 
-func (c *metricWriterTelegrafPrometheusV2) enqueueGauge(resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, gauge pmetric.Gauge, batch InfluxWriterBatch) error {
+func (c *metricWriterTelegrafPrometheusV2) enqueueGauge(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, gauge pmetric.Gauge, batch InfluxWriterBatch) error {
 	for i := 0; i < gauge.DataPoints().Len(); i++ {
 		dataPoint := gauge.DataPoints().At(i)
 		tags, fields, ts, err := c.initMetricTagsAndTimestamp(resource, instrumentationLibrary, dataPoint)
@@ -86,7 +87,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueGauge(resource pcommon.Resourc
 			return fmt.Errorf("unsupported gauge data point type %d", dataPoint.ValueType())
 		}
 
-		if err = batch.EnqueuePoint(common.MeasurementPrometheus, tags, fields, ts, common.InfluxMetricValueTypeGauge); err != nil {
+		if err = batch.EnqueuePoint(ctx, common.MeasurementPrometheus, tags, fields, ts, common.InfluxMetricValueTypeGauge); err != nil {
 			return fmt.Errorf("failed to write point for gauge: %w", err)
 		}
 	}
@@ -94,7 +95,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueGauge(resource pcommon.Resourc
 	return nil
 }
 
-func (c *metricWriterTelegrafPrometheusV2) enqueueGaugeFromSum(resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, sum pmetric.Sum, batch InfluxWriterBatch) error {
+func (c *metricWriterTelegrafPrometheusV2) enqueueGaugeFromSum(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, sum pmetric.Sum, batch InfluxWriterBatch) error {
 
 	for i := 0; i < sum.DataPoints().Len(); i++ {
 		dataPoint := sum.DataPoints().At(i)
@@ -114,7 +115,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueGaugeFromSum(resource pcommon.
 			return fmt.Errorf("unsupported sum (as gauge) data point type %d", dataPoint.ValueType())
 		}
 
-		if err = batch.EnqueuePoint(common.MeasurementPrometheus, tags, fields, ts, common.InfluxMetricValueTypeGauge); err != nil {
+		if err = batch.EnqueuePoint(ctx, common.MeasurementPrometheus, tags, fields, ts, common.InfluxMetricValueTypeGauge); err != nil {
 			return fmt.Errorf("failed to write point for sum (as gauge): %w", err)
 		}
 	}
@@ -122,7 +123,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueGaugeFromSum(resource pcommon.
 	return nil
 }
 
-func (c *metricWriterTelegrafPrometheusV2) enqueueSum(resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, sum pmetric.Sum, batch InfluxWriterBatch) error {
+func (c *metricWriterTelegrafPrometheusV2) enqueueSum(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, sum pmetric.Sum, batch InfluxWriterBatch) error {
 	for i := 0; i < sum.DataPoints().Len(); i++ {
 		dataPoint := sum.DataPoints().At(i)
 		tags, fields, ts, err := c.initMetricTagsAndTimestamp(resource, instrumentationLibrary, dataPoint)
@@ -141,7 +142,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueSum(resource pcommon.Resource,
 			return fmt.Errorf("unsupported sum data point type %d", dataPoint.ValueType())
 		}
 
-		if err = batch.EnqueuePoint(common.MeasurementPrometheus, tags, fields, ts, common.InfluxMetricValueTypeSum); err != nil {
+		if err = batch.EnqueuePoint(ctx, common.MeasurementPrometheus, tags, fields, ts, common.InfluxMetricValueTypeSum); err != nil {
 			return fmt.Errorf("failed to write point for sum: %w", err)
 		}
 	}
@@ -149,7 +150,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueSum(resource pcommon.Resource,
 	return nil
 }
 
-func (c *metricWriterTelegrafPrometheusV2) enqueueHistogram(resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, histogram pmetric.Histogram, batch InfluxWriterBatch) error {
+func (c *metricWriterTelegrafPrometheusV2) enqueueHistogram(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, histogram pmetric.Histogram, batch InfluxWriterBatch) error {
 	for i := 0; i < histogram.DataPoints().Len(); i++ {
 		dataPoint := histogram.DataPoints().At(i)
 		tags, fields, ts, err := c.initMetricTagsAndTimestamp(resource, instrumentationLibrary, dataPoint)
@@ -172,7 +173,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueHistogram(resource pcommon.Res
 				f[measurement+common.MetricHistogramMaxSuffix] = dataPoint.Max()
 			}
 
-			if err = batch.EnqueuePoint(common.MeasurementPrometheus, tags, f, ts, common.InfluxMetricValueTypeHistogram); err != nil {
+			if err = batch.EnqueuePoint(ctx, common.MeasurementPrometheus, tags, f, ts, common.InfluxMetricValueTypeHistogram); err != nil {
 				return fmt.Errorf("failed to write point for histogram: %w", err)
 			}
 		}
@@ -205,7 +206,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueHistogram(resource pcommon.Res
 			t[common.MetricHistogramBoundKeyV2] = boundTagValue
 			f[measurement+common.MetricHistogramBucketSuffix] = float64(bucketCount)
 
-			if err = batch.EnqueuePoint(common.MeasurementPrometheus, t, f, ts, common.InfluxMetricValueTypeHistogram); err != nil {
+			if err = batch.EnqueuePoint(ctx, common.MeasurementPrometheus, t, f, ts, common.InfluxMetricValueTypeHistogram); err != nil {
 				return fmt.Errorf("failed to write point for histogram: %w", err)
 			}
 		}
@@ -214,7 +215,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueHistogram(resource pcommon.Res
 	return nil
 }
 
-func (c *metricWriterTelegrafPrometheusV2) enqueueSummary(resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, summary pmetric.Summary, batch InfluxWriterBatch) error {
+func (c *metricWriterTelegrafPrometheusV2) enqueueSummary(ctx context.Context, resource pcommon.Resource, instrumentationLibrary pcommon.InstrumentationScope, measurement string, summary pmetric.Summary, batch InfluxWriterBatch) error {
 	for i := 0; i < summary.DataPoints().Len(); i++ {
 		dataPoint := summary.DataPoints().At(i)
 		tags, fields, ts, err := c.initMetricTagsAndTimestamp(resource, instrumentationLibrary, dataPoint)
@@ -231,7 +232,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueSummary(resource pcommon.Resou
 			f[measurement+common.MetricSummaryCountSuffix] = float64(dataPoint.Count())
 			f[measurement+common.MetricSummarySumSuffix] = dataPoint.Sum()
 
-			if err = batch.EnqueuePoint(common.MeasurementPrometheus, tags, f, ts, common.InfluxMetricValueTypeSummary); err != nil {
+			if err = batch.EnqueuePoint(ctx, common.MeasurementPrometheus, tags, f, ts, common.InfluxMetricValueTypeSummary); err != nil {
 				return fmt.Errorf("failed to write point for summary: %w", err)
 			}
 		}
@@ -251,7 +252,7 @@ func (c *metricWriterTelegrafPrometheusV2) enqueueSummary(resource pcommon.Resou
 			t[common.MetricSummaryQuantileKeyV2] = quantileTagValue
 			f[measurement] = float64(valueAtQuantile.Value())
 
-			if err = batch.EnqueuePoint(common.MeasurementPrometheus, t, f, ts, common.InfluxMetricValueTypeSummary); err != nil {
+			if err = batch.EnqueuePoint(ctx, common.MeasurementPrometheus, t, f, ts, common.InfluxMetricValueTypeSummary); err != nil {
 				return fmt.Errorf("failed to write point for summary: %w", err)
 			}
 		}

--- a/otel2influx/traces.go
+++ b/otel2influx/traces.go
@@ -223,7 +223,7 @@ func (c *OtelTracesToLineProtocol) enqueueSpan(ctx context.Context, span ptrace.
 		fields[common.AttributeDroppedAttributesCount] = droppedAttributesCount
 	}
 
-	if err = batch.EnqueuePoint(measurement, tags, fields, ts, common.InfluxMetricValueTypeUntyped); err != nil {
+	if err = batch.EnqueuePoint(ctx, measurement, tags, fields, ts, common.InfluxMetricValueTypeUntyped); err != nil {
 		return fmt.Errorf("failed to enqueue point for span: %w", err)
 	}
 
@@ -268,7 +268,7 @@ func (c *OtelTracesToLineProtocol) enqueueSpanEvent(ctx context.Context, traceID
 		common.AttributeSpanID:  hex.EncodeToString(spanID[:]),
 	}
 
-	err := batch.EnqueuePoint(common.MeasurementLogs, tags, fields, spanEvent.Timestamp().AsTime(), common.InfluxMetricValueTypeUntyped)
+	err := batch.EnqueuePoint(ctx, common.MeasurementLogs, tags, fields, spanEvent.Timestamp().AsTime(), common.InfluxMetricValueTypeUntyped)
 	if err != nil {
 		return fmt.Errorf("failed to write point for span event: %w", err)
 	}
@@ -325,7 +325,7 @@ func (c *OtelTracesToLineProtocol) writeSpanLink(ctx context.Context, traceID pc
 		fields[common.AttributeDroppedAttributesCount] = droppedAttributesCount
 	}
 
-	if err := batch.EnqueuePoint(common.MeasurementSpanLinks, tags, fields, ts, common.InfluxMetricValueTypeUntyped); err != nil {
+	if err := batch.EnqueuePoint(ctx, common.MeasurementSpanLinks, tags, fields, ts, common.InfluxMetricValueTypeUntyped); err != nil {
 		return fmt.Errorf("failed to write point for span link: %w", err)
 	}
 	return nil

--- a/otel2influx/writer.go
+++ b/otel2influx/writer.go
@@ -12,7 +12,7 @@ type InfluxWriter interface {
 }
 
 type InfluxWriterBatch interface {
-	EnqueuePoint(measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time, vType common.InfluxMetricValueType) error
+	EnqueuePoint(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time, vType common.InfluxMetricValueType) error
 	WriteBatch(ctx context.Context) error
 }
 
@@ -22,7 +22,7 @@ func (w *NoopInfluxWriter) NewBatch() InfluxWriterBatch {
 	return w
 }
 
-func (w *NoopInfluxWriter) EnqueuePoint(measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time, vType common.InfluxMetricValueType) error {
+func (w *NoopInfluxWriter) EnqueuePoint(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time, vType common.InfluxMetricValueType) error {
 	return nil
 }
 

--- a/otel2influx/writer_test.go
+++ b/otel2influx/writer_test.go
@@ -33,7 +33,7 @@ type MockInfluxWriterBatch struct {
 	w *MockInfluxWriter
 }
 
-func (b *MockInfluxWriterBatch) EnqueuePoint(measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time, vType common.InfluxMetricValueType) error {
+func (b *MockInfluxWriterBatch) EnqueuePoint(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time, vType common.InfluxMetricValueType) error {
 	b.w.points = append(b.w.points, mockPoint{
 		measurement: measurement,
 		tags:        tags,


### PR DESCRIPTION
Helps #262

Adding a context variable so that implementations of InfluxWriterBatch can write a batch early, and prevent downstream buffer errors.

This change will break integration tests until otelcol-contrib and telegraf are updated.