### PR TITLE
fix(otel2influx): handle histogram infinite bucket

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -31,7 +31,7 @@ const (
 	MetricHistogramSumFieldKey   = "sum"
 	MetricHistogramMinFieldKey   = "min"
 	MetricHistogramMaxFieldKey   = "max"
-	MetricHistogramInfFieldKey   = "inf"
+	MetricHistogramInfFieldKey   = "+Inf"
 	MetricHistogramBoundKeyV2    = "le"
 	MetricHistogramCountSuffix   = "_count"
 	MetricHistogramSumSuffix     = "_sum"

--- a/influx2otel/metrics_telegraf_prometheus_v1.go
+++ b/influx2otel/metrics_telegraf_prometheus_v1.go
@@ -257,9 +257,9 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 
 func (b *MetricsBatch) convertHistogramV1(measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time) error {
 	var count uint64
-	foundCount := false
+	var foundCount bool
 	var sum float64
-	foundSum := false
+	var foundSum bool
 	var bucketCounts []uint64
 	var explicitBounds []float64
 
@@ -299,7 +299,6 @@ func (b *MetricsBatch) convertHistogramV1(measurement string, tags map[string]st
 		return fmt.Errorf("histogram sum field not found")
 	}
 
-	bucketCounts = append(bucketCounts, count)
 	sortHistogramBuckets(bucketCounts, explicitBounds)
 
 	bucketsAreCumulative := true

--- a/otel2influx/metrics_telegraf_prometheus_v1.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1.go
@@ -173,13 +173,18 @@ func (c *metricWriterTelegrafPrometheusV1) enqueueHistogram(ctx context.Context,
 			// so accept input if that particular bucket is missing.
 			return fmt.Errorf("invalid metric histogram bucket counts qty %d vs explicit bounds qty %d", bucketCounts.Len(), explicitBounds.Len())
 		}
-		for i := 0; i < explicitBounds.Len(); i++ {
+		for i := 0; i < bucketCounts.Len(); i++ {
 			var bucketCount uint64
 			for j := 0; j <= i; j++ {
 				bucketCount += bucketCounts.At(j)
 			}
 
-			boundFieldKey := strconv.FormatFloat(explicitBounds.At(i), 'f', -1, 64)
+			var boundFieldKey string
+			if explicitBounds.Len() > i {
+				boundFieldKey = strconv.FormatFloat(explicitBounds.At(i), 'f', -1, 64)
+			} else {
+				boundFieldKey = common.MetricHistogramInfFieldKey
+			}
 			fields[boundFieldKey] = float64(bucketCount)
 		}
 

--- a/otel2influx/metrics_telegraf_prometheus_v1_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1_test.go
@@ -286,6 +286,7 @@ func TestWriteMetric_v1_histogram(t *testing.T) {
 					"0.2":                             float64(100392),
 					"0.5":                             float64(129389),
 					"1":                               float64(133988),
+					"+Inf":                            float64(144320),
 					"min":                             float64(0),
 					"max":                             float64(100),
 				},
@@ -325,7 +326,7 @@ func TestWriteMetric_v1_histogram_missingInfinityBucket(t *testing.T) {
 		dp.SetTimestamp(timestamp)
 		dp.SetCount(144320)
 		dp.SetSum(53423)
-		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
+		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599})
 		dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
 
 		err = c.WriteMetrics(context.Background(), metrics)

--- a/otel2influx/metrics_telegraf_prometheus_v2_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2_test.go
@@ -369,6 +369,23 @@ func TestWriteMetric_v2_histogram(t *testing.T) {
 				ts:    timestamp.AsTime().UTC(),
 				vType: common.InfluxMetricValueTypeHistogram,
 			},
+			{
+				measurement: "prometheus",
+				tags: map[string]string{
+					"node":                 "42",
+					"otel.library.name":    "My Library",
+					"otel.library.version": "latest",
+					"method":               "post",
+					"code":                 "200",
+					"le":                   "+Inf",
+				},
+				fields: map[string]interface{}{
+					common.AttributeStartTimeUnixNano:      int64(startTimestamp),
+					"http_request_duration_seconds_bucket": float64(144320),
+				},
+				ts:    timestamp.AsTime().UTC(),
+				vType: common.InfluxMetricValueTypeHistogram,
+			},
 		}
 
 		assert.Equal(t, expected, w.points)
@@ -402,7 +419,7 @@ func TestWriteMetric_v2_histogram_missingInfinityBucket(t *testing.T) {
 		dp.SetTimestamp(timestamp)
 		dp.SetCount(144320)
 		dp.SetSum(53423)
-		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
+		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599})
 		dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
 
 		err = c.WriteMetrics(context.Background(), metrics)

--- a/tests-integration/test_fodder.go
+++ b/tests-integration/test_fodder.go
@@ -7,21 +7,25 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
+type metricTest struct {
+	otel pmetric.Metrics
+	lp   string
+}
+
+type traceTest struct {
+	otel ptrace.Traces
+	lp   string
+}
+
+type logTest struct {
+	otel plog.Logs
+	lp   string
+}
+
 var (
-	metricTests []struct {
-		otel pmetric.Metrics
-		lp   string
-	}
-
-	traceTests []struct {
-		otel ptrace.Traces
-		lp   string
-	}
-
-	logTests []struct {
-		otel plog.Logs
-		lp   string
-	}
+	metricTests []metricTest
+	traceTests  []traceTest
+	logTests    []logTest
 )
 
 func init() {
@@ -63,14 +67,11 @@ func init() {
 		dp.SetTimestamp(pcommon.Timestamp(1622848686000000000))
 		dp.SetDoubleValue(3)
 
-		metricTests = append(metricTests, struct {
-			otel pmetric.Metrics
-			lp   string
-		}{
+		metricTests = append(metricTests, metricTest{
 			otel: metrics,
 			lp: `
 cpu_temp,foo=bar gauge=87.332 1622848686000000000
-http_request_duration_seconds,region=eu count=144320,sum=53423,0.05=24054,0.1=33444,0.2=100392,0.5=129389,1=133988 1622848686000000000
+http_request_duration_seconds,region=eu count=144320,sum=53423,0.05=24054,0.1=33444,0.2=100392,0.5=129389,1=133988,+Inf=144320 1622848686000000000
 http_requests_total,code=200,method=post counter=1027 1622848686000000000
 http_requests_total,code=400,method=post counter=3 1622848686000000000
 `,
@@ -118,10 +119,7 @@ http_requests_total,code=400,method=post counter=3 1622848686000000000
 		span.SetStartTimestamp(pcommon.Timestamp(1622848000000000010))
 		span.SetEndTimestamp(pcommon.Timestamp(1622848000000000012))
 
-		traceTests = append(traceTests, struct {
-			otel ptrace.Traces
-			lp   string
-		}{
+		traceTests = append(traceTests, traceTest{
 			otel: traces,
 			lp: `
 spans,span_id=0000000000000003,trace_id=00000000000000020000000000000001 duration_nano=100000000000i,end_time_unix_nano=1622848100000000000i,span.kind="Internal",attributes="{\"k\":true}",dropped_attributes_count=7u,dropped_events_count=13u,dropped_links_count=17u,span.name="cpu_temp" 1622848000000000000
@@ -147,10 +145,7 @@ spans,span_id=0000000000000005,trace_id=00000000000000020000000000000002 duratio
 		log.SetTraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1})
 		log.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 3})
 
-		logTests = append(logTests, struct {
-			otel plog.Logs
-			lp   string
-		}{
+		logTests = append(logTests, logTest{
 			otel: logs,
 			lp: `
 logs,span_id=0000000000000003,trace_id=00000000000000020000000000000001 body="something-happened",k=true,dropped_attributes_count=5u,severity_number=9i,severity_text="info" 1622848686000000000


### PR DESCRIPTION
Closes #143

This adds the `+Inf` bucket to histograms iff the otel Histogram contains the extra bucket.