### PR TITLE
fix: remove flags field

### DIFF
--- a/docs/logs.md
+++ b/docs/logs.md
@@ -39,7 +39,7 @@ timestamp                                           | `time_unix_nano` fixed64  
 `otel.log.dropped_attributes_count` field uint      | `dropped_attributes_count` uint32
 `severity_number` tag uint                          | `severity_number` enum SeverityNumber           |                                                           | `level` number                                       | `PRI severity` integer     | `PRI severity` integer
 `severity_text` field string                        | `severity_text` string
-`otel.log.flags` field uint                         | `flags` fixed32
+.                                                   | `flags` fixed32
 .                                                   | `attributes["fluent.tag"]` string               | `tag` string
 .                                                   | `Resource.attributes["net.host.name"]` string   |                                                           | `host` string                                        | `HEADER hostname` string   | `HOSTNAME` string
 .                                                   | `Resource.attributes["net.host.ip"]` string     |                                                           |                                                      | `HEADER IP address` string | `HOSTNAME` string

--- a/influx2otel/metrics_telegraf_prometheus_v1.go
+++ b/influx2otel/metrics_telegraf_prometheus_v1.go
@@ -94,11 +94,6 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 				}
 			}
 		}
-		if flagsObj, ok := fields[common.AttributeFlags]; ok {
-			if flagsUint64, ok := flagsObj.(uint64); ok {
-				dataPoint.SetFlags(pmetric.DataPointFlags(flagsUint64))
-			}
-		}
 
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
@@ -114,7 +109,7 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 		var floatValue *float64
 		var intValue *int64
 
-		if k == common.AttributeStartTimeStatsd || k == common.AttributeFlags {
+		if k == common.AttributeStartTimeStatsd {
 			continue
 		}
 		switch typedValue := fieldValue.(type) {
@@ -143,11 +138,6 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 				if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
 					dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
 				}
-			}
-		}
-		if flagsObj, ok := fields[common.AttributeFlags]; ok {
-			if flagsUint64, ok := flagsObj.(uint64); ok {
-				dataPoint.SetFlags(pmetric.DataPointFlags(flagsUint64))
 			}
 		}
 
@@ -193,11 +183,6 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 				}
 			}
 		}
-		if flagsObj, ok := fields[common.AttributeFlags]; ok {
-			if flagsUint64, ok := flagsObj.(uint64); ok {
-				dataPoint.SetFlags(pmetric.DataPointFlags(flagsUint64))
-			}
-		}
 
 		if floatValue != nil {
 			dataPoint.SetDoubleValue(*floatValue)
@@ -211,7 +196,7 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 	}
 
 	for k, fieldValue := range fields {
-		if k == common.AttributeStartTimeStatsd || k == common.AttributeFlags {
+		if k == common.AttributeStartTimeStatsd {
 			continue
 		}
 
@@ -243,11 +228,6 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 				if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
 					dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
 				}
-			}
-		}
-		if flagsObj, ok := fields[common.AttributeFlags]; ok {
-			if flagsUint64, ok := flagsObj.(uint64); ok {
-				dataPoint.SetFlags(pmetric.DataPointFlags(flagsUint64))
 			}
 		}
 
@@ -295,7 +275,7 @@ func (b *MetricsBatch) convertHistogramV1(measurement string, tags map[string]st
 				bucketCounts = append(bucketCounts, uint64(vBucketCount))
 			}
 
-		} else if k == common.AttributeStartTimeStatsd || k == common.AttributeFlags {
+		} else if k == common.AttributeStartTimeStatsd {
 		} else {
 			b.logger.Debug("skipping unrecognized histogram field", "field", k, "value", vi)
 		}
@@ -335,11 +315,6 @@ func (b *MetricsBatch) convertHistogramV1(measurement string, tags map[string]st
 			if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
 				dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
 			}
-		}
-	}
-	if flagsObj, ok := fields[common.AttributeFlags]; ok {
-		if flagsUint64, ok := flagsObj.(uint64); ok {
-			dataPoint.SetFlags(pmetric.DataPointFlags(flagsUint64))
 		}
 	}
 
@@ -382,7 +357,7 @@ func (b *MetricsBatch) convertSummaryV1(measurement string, tags map[string]stri
 				valueAtQuantile.SetValue(value)
 			}
 
-		} else if k == common.AttributeStartTimeStatsd || k == common.AttributeFlags {
+		} else if k == common.AttributeStartTimeStatsd {
 		} else {
 			b.logger.Debug("skipping unrecognized summary field", "field", k, "value", vi)
 		}
@@ -406,11 +381,6 @@ func (b *MetricsBatch) convertSummaryV1(measurement string, tags map[string]stri
 			if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
 				dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(t))
 			}
-		}
-	}
-	if flagsObj, ok := fields[common.AttributeFlags]; ok {
-		if flagsUint64, ok := flagsObj.(uint64); ok {
-			dataPoint.SetFlags(pmetric.DataPointFlags(flagsUint64))
 		}
 	}
 

--- a/influx2otel/metrics_telegraf_prometheus_v1_test.go
+++ b/influx2otel/metrics_telegraf_prometheus_v1_test.go
@@ -27,7 +27,6 @@ func TestAddPoint_v1_gauge(t *testing.T) {
 		},
 		map[string]interface{}{
 			"gauge": float64(23.9),
-			"flags": uint64(1),
 		},
 		time.Unix(0, 1395066363000000123).UTC(),
 		common.InfluxMetricValueTypeGauge)
@@ -60,12 +59,10 @@ func TestAddPoint_v1_gauge(t *testing.T) {
 	dp.Attributes().PutStr("engine_id", "0")
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(23.9)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "1")
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(11.9)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 
 	assertMetricsEqual(t, expect, b.GetMetrics())
 }
@@ -84,7 +81,6 @@ func TestAddPoint_v1_untypedGauge(t *testing.T) {
 		},
 		map[string]interface{}{
 			"gauge": float64(23.9),
-			"flags": uint64(1),
 		},
 		time.Unix(0, 1395066363000000123).UTC(),
 		common.InfluxMetricValueTypeUntyped)
@@ -117,12 +113,10 @@ func TestAddPoint_v1_untypedGauge(t *testing.T) {
 	dp.Attributes().PutStr("engine_id", "0")
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(23.9)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("engine_id", "1")
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(11.9)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 
 	assertMetricsEqual(t, expect, b.GetMetrics())
 }
@@ -142,7 +136,6 @@ func TestAddPoint_v1_sum(t *testing.T) {
 		},
 		map[string]interface{}{
 			"counter": float64(1027),
-			"flags":   uint64(1),
 		},
 		time.Unix(0, 1395066363000000123).UTC(),
 		common.InfluxMetricValueTypeSum)
@@ -179,13 +172,11 @@ func TestAddPoint_v1_sum(t *testing.T) {
 	dp.Attributes().PutStr("method", "post")
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(1027)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	dp = m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "400")
 	dp.Attributes().PutStr("method", "post")
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(3)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 
 	assertMetricsEqual(t, expect, b.GetMetrics())
 }
@@ -205,7 +196,6 @@ func TestAddPoint_v1_untypedSum(t *testing.T) {
 		},
 		map[string]interface{}{
 			"counter": float64(1027),
-			"flags":   uint64(0),
 		},
 		time.Unix(0, 1395066363000000123).UTC(),
 		common.InfluxMetricValueTypeUntyped)
@@ -242,13 +232,11 @@ func TestAddPoint_v1_untypedSum(t *testing.T) {
 	dp.Attributes().PutStr("method", "post")
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(1027)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 	dp = m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutStr("code", "400")
 	dp.Attributes().PutStr("method", "post")
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetDoubleValue(3)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 
 	assertMetricsEqual(t, expect, b.GetMetrics())
 }
@@ -275,7 +263,6 @@ func TestAddPoint_v1_histogram(t *testing.T) {
 			"0.5":   float64(129389),
 			"1":     float64(133988),
 			"+Inf":  float64(144320),
-			"flags": uint64(1),
 		},
 		time.Unix(0, 1395066363000000123).UTC(),
 		common.InfluxMetricValueTypeHistogram)
@@ -299,7 +286,6 @@ func TestAddPoint_v1_histogram(t *testing.T) {
 	dp.SetSum(53423)
 	dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
 	dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 
 	assertMetricsEqual(t, expect, b.GetMetrics())
 }
@@ -325,7 +311,6 @@ func TestAddPoint_v1_histogram_missingInfinityBucket(t *testing.T) {
 			"0.2":   float64(100392),
 			"0.5":   float64(129389),
 			"1":     float64(133988),
-			"flags": uint64(0),
 		},
 		time.Unix(0, 1395066363000000123).UTC(),
 		common.InfluxMetricValueTypeHistogram)
@@ -349,7 +334,6 @@ func TestAddPoint_v1_histogram_missingInfinityBucket(t *testing.T) {
 	dp.SetSum(53423)
 	dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
 	dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 
 	assertMetricsEqual(t, expect, b.GetMetrics())
 }
@@ -375,7 +359,6 @@ func TestAddPoint_v1_untypedHistogram(t *testing.T) {
 			"0.2":   float64(100392),
 			"0.5":   float64(129389),
 			"1":     float64(133988),
-			"flags": uint64(1),
 		},
 		time.Unix(0, 1395066363000000123).UTC(),
 		common.InfluxMetricValueTypeUntyped)
@@ -399,7 +382,6 @@ func TestAddPoint_v1_untypedHistogram(t *testing.T) {
 	dp.SetSum(53423)
 	dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
 	dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 
 	assertMetricsEqual(t, expect, b.GetMetrics())
 }
@@ -425,7 +407,6 @@ func TestAddPoint_v1_summary(t *testing.T) {
 			"0.5":   float64(4773),
 			"0.9":   float64(9001),
 			"0.99":  float64(76656),
-			"flags": uint64(1),
 		},
 		time.Unix(0, 1395066363000000123),
 		common.InfluxMetricValueTypeSummary)
@@ -446,7 +427,6 @@ func TestAddPoint_v1_summary(t *testing.T) {
 	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 1395066363000000123)))
 	dp.SetCount(2693)
 	dp.SetSum(17560473)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	qv := dp.QuantileValues().AppendEmpty()
 	qv.SetQuantile(0.01)
 	qv.SetValue(3102)
@@ -487,7 +467,6 @@ func TestAddPoint_v1_untypedSummary(t *testing.T) {
 			"0.5":   float64(4773),
 			"0.9":   float64(9001),
 			"0.99":  float64(76656),
-			"flags": uint64(0),
 		},
 		time.Unix(0, 1395066363000000123).UTC(),
 		common.InfluxMetricValueTypeUntyped)
@@ -511,7 +490,6 @@ func TestAddPoint_v1_untypedSummary(t *testing.T) {
 	dp.SetSum(17560473)
 	dp.BucketCounts().FromRaw([]uint64{3102, 170, 1501, 4228, 67655, 2693})
 	dp.ExplicitBounds().FromRaw([]float64{0.01, 0.05, 0.5, 0.9, 0.99})
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 
 	assertMetricsEqual(t, expect, b.GetMetrics())
 }

--- a/otel2influx/README.md
+++ b/otel2influx/README.md
@@ -66,8 +66,8 @@ For example:
 - `Metric.unit` is ignored
 - `Metric` values are assigned field keys `gauge`, `counter`, `count`, `sum`, `inf`
   - Metric conversion follows Prometheus conventions for compatibility
-- `LogRecord.flags` is ignored
-  - This is an enum with no values defines yet
+- `flags` fields are ignored
+  - These are enum with no values defines yet
 
 ## Example Line Protocol
 

--- a/otel2influx/logs.go
+++ b/otel2influx/logs.go
@@ -102,7 +102,6 @@ func (c *OtelLogsToLineProtocol) enqueueLogRecord(ctx context.Context, resource 
 	tags := make(map[string]string, len(c.logRecordDimensions)+2)
 	fields := make(map[string]interface{})
 
-	fields[common.AttributeFlags] = uint64(logRecord.Flags())
 	if ots := logRecord.ObservedTimestamp().AsTime(); !ots.IsZero() && !ots.Equal(time.Unix(0, 0)) {
 		fields[common.AttributeObservedTimeUnixNano] = ots.UnixNano()
 	}

--- a/otel2influx/metrics.go
+++ b/otel2influx/metrics.go
@@ -79,5 +79,4 @@ type basicDataPoint interface {
 	Timestamp() pcommon.Timestamp
 	StartTimestamp() pcommon.Timestamp
 	Attributes() pcommon.Map
-	Flags() pmetric.DataPointFlags
 }

--- a/otel2influx/metrics_otel_v1.go
+++ b/otel2influx/metrics_otel_v1.go
@@ -85,7 +85,6 @@ func (m *metricWriterOtelV1) enqueueSum(ctx context.Context, measurementName str
 
 	for i := 0; i < pm.Sum().DataPoints().Len(); i++ {
 		// TODO datapoint exemplars
-		// TODO datapoint flags
 		dataPoint := pm.Sum().DataPoints().At(i)
 
 		fields := make(map[string]interface{}, 3)
@@ -116,7 +115,6 @@ func (m *metricWriterOtelV1) enqueueHistogram(ctx context.Context, measurementNa
 
 	for i := 0; i < pm.Histogram().DataPoints().Len(); i++ {
 		// TODO datapoint exemplars
-		// TODO datapoint flags
 		dataPoint := pm.Histogram().DataPoints().At(i)
 
 		bucketCounts, explicitBounds := dataPoint.BucketCounts(), dataPoint.ExplicitBounds()

--- a/otel2influx/metrics_telegraf_prometheus_v1.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1.go
@@ -49,7 +49,6 @@ func (c *metricWriterTelegrafPrometheusV1) initMetricTagsAndTimestamp(dataPoint 
 	if dataPoint.StartTimestamp() != 0 {
 		fields[common.AttributeStartTimeUnixNano] = int64(dataPoint.StartTimestamp())
 	}
-	fields[common.AttributeFlags] = uint64(dataPoint.Flags())
 
 	tags = maps.Clone(tags)
 	dataPoint.Attributes().Range(func(k string, v pcommon.Value) bool {

--- a/otel2influx/metrics_telegraf_prometheus_v1_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1_test.go
@@ -37,7 +37,6 @@ func TestWriteMetric_v1_gauge(t *testing.T) {
 	dp.SetStartTimestamp(startTimestamp)
 	dp.SetTimestamp(timestamp)
 	dp.SetDoubleValue(23.9)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutInt("engine_id", 1)
 	dp.SetStartTimestamp(startTimestamp)
@@ -59,7 +58,6 @@ func TestWriteMetric_v1_gauge(t *testing.T) {
 			fields: map[string]interface{}{
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"gauge":                           float64(23.9),
-				"flags":                           uint64(1),
 			},
 			ts:    time.Unix(0, 1395066363000000123).UTC(),
 			vType: common.InfluxMetricValueTypeGauge,
@@ -75,7 +73,6 @@ func TestWriteMetric_v1_gauge(t *testing.T) {
 			fields: map[string]interface{}{
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"gauge":                           float64(11.9),
-				"flags":                           uint64(0),
 			},
 			ts:    time.Unix(0, 1395066363000000123).UTC(),
 			vType: common.InfluxMetricValueTypeGauge,
@@ -128,7 +125,6 @@ func TestWriteMetric_v1_gaugeFromSum(t *testing.T) {
 		dp.SetStartTimestamp(startTimestamp)
 		dp.SetTimestamp(timestamp)
 		dp.SetDoubleValue(23.9)
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 		dp = m.Sum().DataPoints().AppendEmpty()
 		dp.Attributes().PutInt("engine_id", 1)
 		dp.SetStartTimestamp(startTimestamp)
@@ -150,7 +146,6 @@ func TestWriteMetric_v1_gaugeFromSum(t *testing.T) {
 				fields: map[string]interface{}{
 					common.AttributeStartTimeUnixNano: int64(startTimestamp),
 					"gauge":                           float64(23.9),
-					"flags":                           uint64(1),
 				},
 				ts:    time.Unix(0, 1395066363000000123).UTC(),
 				vType: common.InfluxMetricValueTypeGauge,
@@ -166,7 +161,6 @@ func TestWriteMetric_v1_gaugeFromSum(t *testing.T) {
 				fields: map[string]interface{}{
 					common.AttributeStartTimeUnixNano: int64(startTimestamp),
 					"gauge":                           float64(11.9),
-					"flags":                           uint64(0),
 				},
 				ts:    time.Unix(0, 1395066363000000123).UTC(),
 				vType: common.InfluxMetricValueTypeGauge,
@@ -203,7 +197,6 @@ func TestWriteMetric_v1_sum(t *testing.T) {
 	dp.SetStartTimestamp(startTimestamp)
 	dp.SetTimestamp(timestamp)
 	dp.SetDoubleValue(1027)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	dp = m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutInt("code", 400)
 	dp.Attributes().PutStr("method", "post")
@@ -227,7 +220,6 @@ func TestWriteMetric_v1_sum(t *testing.T) {
 			fields: map[string]interface{}{
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"counter":                         float64(1027),
-				"flags":                           uint64(1),
 			},
 			ts:    time.Unix(0, 1395066363000000123).UTC(),
 			vType: common.InfluxMetricValueTypeSum,
@@ -244,7 +236,6 @@ func TestWriteMetric_v1_sum(t *testing.T) {
 			fields: map[string]interface{}{
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"counter":                         float64(3),
-				"flags":                           uint64(0),
 			},
 			ts:    time.Unix(0, 1395066363000000123).UTC(),
 			vType: common.InfluxMetricValueTypeSum,
@@ -285,7 +276,6 @@ func TestWriteMetric_v1_histogram(t *testing.T) {
 		dp.SetMax(100)
 		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
 		dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 
 		err = c.WriteMetrics(context.Background(), metrics)
 		require.NoError(t, err)
@@ -312,7 +302,6 @@ func TestWriteMetric_v1_histogram(t *testing.T) {
 					"+Inf":                            float64(144320),
 					"min":                             float64(0),
 					"max":                             float64(100),
-					"flags":                           uint64(1),
 				},
 				ts:    time.Unix(0, 1395066363000000123).UTC(),
 				vType: common.InfluxMetricValueTypeHistogram,
@@ -375,7 +364,6 @@ func TestWriteMetric_v1_histogram_missingInfinityBucket(t *testing.T) {
 					"0.2":                             float64(100392),
 					"0.5":                             float64(129389),
 					"1":                               float64(133988),
-					"flags":                           uint64(0),
 				},
 				ts:    time.Unix(0, 1395066363000000123).UTC(),
 				vType: common.InfluxMetricValueTypeHistogram,
@@ -411,7 +399,6 @@ func TestWriteMetric_v1_summary(t *testing.T) {
 	dp.SetTimestamp(timestamp)
 	dp.SetCount(2693)
 	dp.SetSum(17560473)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	qv := dp.QuantileValues().AppendEmpty()
 	qv.SetQuantile(0.01)
 	qv.SetValue(3102)
@@ -450,7 +437,6 @@ func TestWriteMetric_v1_summary(t *testing.T) {
 				"0.5":                             float64(4773),
 				"0.9":                             float64(9001),
 				"0.99":                            float64(76656),
-				"flags":                           uint64(1),
 			},
 			ts:    time.Unix(0, 1395066363000000123).UTC(),
 			vType: common.InfluxMetricValueTypeSummary,

--- a/otel2influx/metrics_telegraf_prometheus_v2.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2.go
@@ -49,7 +49,6 @@ func (c *metricWriterTelegrafPrometheusV2) initMetricTagsAndTimestamp(dataPoint 
 	if dataPoint.StartTimestamp() != 0 {
 		fields[common.AttributeStartTimeUnixNano] = int64(dataPoint.StartTimestamp())
 	}
-	fields[common.AttributeFlags] = uint64(dataPoint.Flags())
 
 	tags = maps.Clone(tags)
 	dataPoint.Attributes().Range(func(k string, v pcommon.Value) bool {

--- a/otel2influx/metrics_telegraf_prometheus_v2_test.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2_test.go
@@ -36,7 +36,6 @@ func TestWriteMetric_v2_gauge(t *testing.T) {
 	dp.SetStartTimestamp(startTimestamp)
 	dp.SetTimestamp(timestamp)
 	dp.SetDoubleValue(23.9)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	dp = m.Gauge().DataPoints().AppendEmpty()
 	dp.Attributes().PutInt("engine_id", 1)
 	dp.SetStartTimestamp(startTimestamp)
@@ -58,7 +57,6 @@ func TestWriteMetric_v2_gauge(t *testing.T) {
 			fields: map[string]interface{}{
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"cache_age_seconds":               float64(23.9),
-				"flags":                           uint64(1),
 			},
 			ts:    timestamp.AsTime().UTC(),
 			vType: common.InfluxMetricValueTypeGauge,
@@ -74,7 +72,6 @@ func TestWriteMetric_v2_gauge(t *testing.T) {
 			fields: map[string]interface{}{
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"cache_age_seconds":               float64(11.9),
-				"flags":                           uint64(0),
 			},
 			ts:    timestamp.AsTime().UTC(),
 			vType: common.InfluxMetricValueTypeGauge,
@@ -125,7 +122,6 @@ func TestWriteMetric_v2_gaugeFromSum(t *testing.T) {
 		dp.SetStartTimestamp(startTimestamp)
 		dp.SetTimestamp(timestamp)
 		dp.SetDoubleValue(23.9)
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 		dp = m.Sum().DataPoints().AppendEmpty()
 		dp.Attributes().PutInt("engine_id", 1)
 		dp.SetStartTimestamp(startTimestamp)
@@ -147,7 +143,6 @@ func TestWriteMetric_v2_gaugeFromSum(t *testing.T) {
 				fields: map[string]interface{}{
 					common.AttributeStartTimeUnixNano: int64(startTimestamp),
 					"cache_age_seconds":               float64(23.9),
-					"flags":                           uint64(1),
 				},
 				ts:    timestamp.AsTime().UTC(),
 				vType: common.InfluxMetricValueTypeGauge,
@@ -163,7 +158,6 @@ func TestWriteMetric_v2_gaugeFromSum(t *testing.T) {
 				fields: map[string]interface{}{
 					common.AttributeStartTimeUnixNano: int64(startTimestamp),
 					"cache_age_seconds":               float64(11.9),
-					"flags":                           uint64(0),
 				},
 				ts:    timestamp.AsTime().UTC(),
 				vType: common.InfluxMetricValueTypeGauge,
@@ -200,7 +194,6 @@ func TestWriteMetric_v2_sum(t *testing.T) {
 	dp.SetStartTimestamp(startTimestamp)
 	dp.SetTimestamp(timestamp)
 	dp.SetDoubleValue(1027)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	dp = m.Sum().DataPoints().AppendEmpty()
 	dp.Attributes().PutInt("code", 400)
 	dp.Attributes().PutStr("method", "post")
@@ -224,7 +217,6 @@ func TestWriteMetric_v2_sum(t *testing.T) {
 			fields: map[string]interface{}{
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"http_requests_total":             float64(1027),
-				"flags":                           uint64(1),
 			},
 			ts:    timestamp.AsTime().UTC(),
 			vType: common.InfluxMetricValueTypeSum,
@@ -241,7 +233,6 @@ func TestWriteMetric_v2_sum(t *testing.T) {
 			fields: map[string]interface{}{
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"http_requests_total":             float64(3),
-				"flags":                           uint64(0),
 			},
 			ts:    timestamp.AsTime().UTC(),
 			vType: common.InfluxMetricValueTypeSum,
@@ -282,7 +273,6 @@ func TestWriteMetric_v2_histogram(t *testing.T) {
 		dp.SetMax(100)
 		dp.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
 		dp.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 
 		err = c.WriteMetrics(context.Background(), metrics)
 		require.NoError(t, err)
@@ -303,7 +293,6 @@ func TestWriteMetric_v2_histogram(t *testing.T) {
 					"http_request_duration_seconds_sum":   float64(53423),
 					"http_request_duration_seconds_min":   float64(0),
 					"http_request_duration_seconds_max":   float64(100),
-					"flags":                               uint64(1),
 				},
 				ts:    timestamp.AsTime().UTC(),
 				vType: common.InfluxMetricValueTypeHistogram,
@@ -457,7 +446,6 @@ func TestWriteMetric_v2_histogram_missingInfinityBucket(t *testing.T) {
 					common.AttributeStartTimeUnixNano:     int64(startTimestamp),
 					"http_request_duration_seconds_count": float64(144320),
 					"http_request_duration_seconds_sum":   float64(53423),
-					"flags":                               uint64(0),
 				},
 				ts:    timestamp.AsTime().UTC(),
 				vType: common.InfluxMetricValueTypeHistogram,
@@ -573,7 +561,6 @@ func TestWriteMetric_v2_summary(t *testing.T) {
 	dp.SetTimestamp(timestamp)
 	dp.SetCount(2693)
 	dp.SetSum(17560473)
-	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	qv := dp.QuantileValues().AppendEmpty()
 	qv.SetQuantile(0.01)
 	qv.SetValue(3102)
@@ -607,7 +594,6 @@ func TestWriteMetric_v2_summary(t *testing.T) {
 				common.AttributeStartTimeUnixNano: int64(startTimestamp),
 				"rpc_duration_seconds_count":      float64(2693),
 				"rpc_duration_seconds_sum":        float64(17560473),
-				"flags":                           uint64(1),
 			},
 			ts:    timestamp.AsTime().UTC(),
 			vType: common.InfluxMetricValueTypeSummary,

--- a/tests-integration/test_fodder.go
+++ b/tests-integration/test_fodder.go
@@ -40,7 +40,6 @@ func init() {
 		dp.Attributes().PutStr("foo", "bar")
 		dp.SetTimestamp(pcommon.Timestamp(1622848686000000000))
 		dp.SetDoubleValue(87.332)
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 		m = isMetrics.Metrics().AppendEmpty()
 		m.SetName("http_request_duration_seconds")
 		m.SetEmptyHistogram()
@@ -52,7 +51,6 @@ func init() {
 		dp2.SetSum(53423)
 		dp2.ExplicitBounds().FromRaw([]float64{0.05, 0.1, 0.2, 0.5, 1})
 		dp2.BucketCounts().FromRaw([]uint64{24054, 9390, 66948, 28997, 4599, 10332})
-		dp2.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 		m = isMetrics.Metrics().AppendEmpty()
 		m.SetName("http_requests_total")
 		m.SetEmptySum()
@@ -63,21 +61,19 @@ func init() {
 		dp.Attributes().PutStr("code", "200")
 		dp.SetTimestamp(pcommon.Timestamp(1622848686000000000))
 		dp.SetDoubleValue(1027)
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 		dp = m.Sum().DataPoints().AppendEmpty()
 		dp.Attributes().PutStr("method", "post")
 		dp.Attributes().PutStr("code", "400")
 		dp.SetTimestamp(pcommon.Timestamp(1622848686000000000))
 		dp.SetDoubleValue(3)
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 
 		metricTests = append(metricTests, metricTest{
 			otel: metrics,
 			lp: `
-cpu_temp,foo=bar gauge=87.332,flags=1u 1622848686000000000
-http_request_duration_seconds,region=eu count=144320,sum=53423,flags=0u,0.05=24054,0.1=33444,0.2=100392,0.5=129389,1=133988,+Inf=144320 1622848686000000000
-http_requests_total,code=200,method=post counter=1027,flags=1u 1622848686000000000
-http_requests_total,code=400,method=post counter=3,flags=0u 1622848686000000000
+cpu_temp,foo=bar gauge=87.332 1622848686000000000
+http_request_duration_seconds,region=eu count=144320,sum=53423,0.05=24054,0.1=33444,0.2=100392,0.5=129389,1=133988,+Inf=144320 1622848686000000000
+http_requests_total,code=200,method=post counter=1027 1622848686000000000
+http_requests_total,code=400,method=post counter=3 1622848686000000000
 `,
 		})
 	}
@@ -148,12 +144,11 @@ spans,span_id=0000000000000005,trace_id=00000000000000020000000000000002 duratio
 		log.SetDroppedAttributesCount(5)
 		log.SetTraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1})
 		log.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 3})
-		log.SetFlags(plog.DefaultLogRecordFlags.WithIsSampled(true))
 
 		logTests = append(logTests, logTest{
 			otel: logs,
 			lp: `
-logs,span_id=0000000000000003,trace_id=00000000000000020000000000000001 body="something-happened",attributes="{\"k\":true}",dropped_attributes_count=5u,flags=1u,severity_number=9i,severity_text="info" 1622848686000000000
+logs,span_id=0000000000000003,trace_id=00000000000000020000000000000001 body="something-happened",attributes="{\"k\":true}",dropped_attributes_count=5u,severity_number=9i,severity_text="info" 1622848686000000000
 `,
 		})
 	}


### PR DESCRIPTION
Helps https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29896

The flags field is set as an unsigned integer, which is not compatible with InfluxDB 1.x. Luckily, the field is also not useful, as it stores a value chosen from an enum containing no useful values.

In this change, the flags field is removed from conversion. If it needs to be added in the future, we can expect that enough time will have passed that retention policies will have removed the prior `flags` field.

There are other fields that use the unsigned integer type, but those fields belong to Logs and Traces, which shouldn't be used with InfluxDB 1.x anyhow.