### PR TITLE
otel2influx: metrics name has prefix field__ covert to fields #310

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -1,4 +1,4 @@
-module github.com/influxdata/influxdb-observability/common
+module github.com/bobbyliyao/influxdb-observability/common
 
 go 1.21.0
 

--- a/influx2otel/go.mod
+++ b/influx2otel/go.mod
@@ -1,4 +1,4 @@
-module github.com/influxdata/influxdb-observability/influx2otel
+module github.com/bobbyliyao/influxdb-observability/influx2otel
 
 go 1.21.0
 

--- a/otel2influx/go.mod
+++ b/otel2influx/go.mod
@@ -1,4 +1,4 @@
-module github.com/influxdata/influxdb-observability/otel2influx
+module github.com/bobbyliyao/influxdb-observability/otel2influx
 
 go 1.21.0
 

--- a/otel2influx/metrics_telegraf_prometheus_v1.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -59,7 +60,7 @@ func (c *metricWriterTelegrafPrometheusV1) initMetricTagsAndTimestamp(dataPoint 
 				case pcommon.ValueTypeStr:
 					fields[k] = v.Str()
 				case pcommon.ValueTypeInt:
-					fields[k] = v.Int()
+					fields[k] = v.Double()
 				case pcommon.ValueTypeDouble:
 					fields[k] = v.Double()
 				case pcommon.ValueTypeBool:

--- a/otel2influx/metrics_telegraf_prometheus_v1.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1.go
@@ -53,7 +53,12 @@ func (c *metricWriterTelegrafPrometheusV1) initMetricTagsAndTimestamp(dataPoint 
 	tags = maps.Clone(tags)
 	dataPoint.Attributes().Range(func(k string, v pcommon.Value) bool {
 		if k != "" {
-			tags[k] = v.AsString()
+			if strings.HasPrefix(k, "field__") {
+				k = strings.TrimPrefix(k, "field__")
+				fields[k] = v
+			} else {
+				tags[k] = v.AsString()
+			}
 		}
 		return true
 	})

--- a/otel2influx/metrics_telegraf_prometheus_v1.go
+++ b/otel2influx/metrics_telegraf_prometheus_v1.go
@@ -53,9 +53,20 @@ func (c *metricWriterTelegrafPrometheusV1) initMetricTagsAndTimestamp(dataPoint 
 	tags = maps.Clone(tags)
 	dataPoint.Attributes().Range(func(k string, v pcommon.Value) bool {
 		if k != "" {
-			if strings.HasPrefix(k, "field__") {
-				k = strings.TrimPrefix(k, "field__")
-				fields[k] = v
+			if strings.HasPrefix(k, "field_") {
+				k = strings.TrimPrefix(k, "field_")
+				switch v.Type() {
+				case pcommon.ValueTypeStr:
+					fields[k] = v.Str()
+				case pcommon.ValueTypeInt:
+					fields[k] = v.Int()
+				case pcommon.ValueTypeDouble:
+					fields[k] = v.Double()
+				case pcommon.ValueTypeBool:
+					fields[k] = v.Bool()
+				default:
+				}
+
 			} else {
 				tags[k] = v.AsString()
 			}

--- a/otel2influx/metrics_telegraf_prometheus_v2.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -59,7 +60,7 @@ func (c *metricWriterTelegrafPrometheusV2) initMetricTagsAndTimestamp(dataPoint 
 				case pcommon.ValueTypeStr:
 					fields[k] = v.Str()
 				case pcommon.ValueTypeInt:
-					fields[k] = v.Int()
+					fields[k] = v.Double()
 				case pcommon.ValueTypeDouble:
 					fields[k] = v.Double()
 				case pcommon.ValueTypeBool:

--- a/otel2influx/metrics_telegraf_prometheus_v2.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2.go
@@ -53,7 +53,12 @@ func (c *metricWriterTelegrafPrometheusV2) initMetricTagsAndTimestamp(dataPoint 
 	tags = maps.Clone(tags)
 	dataPoint.Attributes().Range(func(k string, v pcommon.Value) bool {
 		if k != "" {
-			tags[k] = v.AsString()
+			if strings.HasPrefix(k, "field__") {
+				k = strings.TrimPrefix(k, "field__")
+				fields[k] = v
+			} else {
+				tags[k] = v.AsString()
+			}
 		}
 		return true
 	})

--- a/otel2influx/metrics_telegraf_prometheus_v2.go
+++ b/otel2influx/metrics_telegraf_prometheus_v2.go
@@ -53,16 +53,26 @@ func (c *metricWriterTelegrafPrometheusV2) initMetricTagsAndTimestamp(dataPoint 
 	tags = maps.Clone(tags)
 	dataPoint.Attributes().Range(func(k string, v pcommon.Value) bool {
 		if k != "" {
-			if strings.HasPrefix(k, "field__") {
-				k = strings.TrimPrefix(k, "field__")
-				fields[k] = v
+			if strings.HasPrefix(k, "field_") {
+				k = strings.TrimPrefix(k, "field_")
+				switch v.Type() {
+				case pcommon.ValueTypeStr:
+					fields[k] = v.Str()
+				case pcommon.ValueTypeInt:
+					fields[k] = v.Int()
+				case pcommon.ValueTypeDouble:
+					fields[k] = v.Double()
+				case pcommon.ValueTypeBool:
+					fields[k] = v.Bool()
+				default:
+				}
+
 			} else {
 				tags[k] = v.AsString()
 			}
 		}
 		return true
 	})
-
 	return tags, fields, ts, nil
 }
 


### PR DESCRIPTION
In issue #310, someone mentioned the desire to differentiate whether metrics should be written to fields or tags based on their names. I have encountered the same issue and hope to address it through a pull request.