### PR TITLE
build(ci): Update to supported go versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @influxdata/iox-write
+* @influxdata/iox-write @influxdata/iox-query

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,68 +2,67 @@ name: ci
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-
   build:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.21", "1.22" ]
-        package: [ "common", "influx2otel", "otel2influx", "jaeger-influxdb", "tests-integration" ]
-        exclude:
-        - go: 1.21
-          package: jaeger-influxdb
-        - go: 1.21
-          package: tests-integration
+        go: ["1.23", "1.24"]
+        package:
+          [
+            "common",
+            "influx2otel",
+            "otel2influx",
+            "jaeger-influxdb",
+            "tests-integration",
+          ]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Test
+        run: >
+          cd ${{ matrix.package }} &&
+          go test ./...
 
-    - name: Test
-      run: >
-        cd ${{ matrix.package }} &&
-        go test ./...
+      - name: Fmt
+        run: >
+          test -z $(gofmt -s -l ./${{ matrix.package }} | head -n 1) || ( gofmt -s -d ./${{ matrix.package }} ; exit 1 )
 
-    - name: Fmt
-      run: >
-        test -z $(gofmt -s -l ./${{ matrix.package }} | head -n 1) || ( gofmt -s -d ./${{ matrix.package }} ; exit 1 )
+      - name: Vet
+        run: >
+          cd ${{ matrix.package }} &&
+          go vet ./...
 
-    - name: Vet
-      run: >
-        cd ${{ matrix.package }} &&
-        go vet ./...
-
-    - name: staticcheck
-      run: >
-        go install honnef.co/go/tools/cmd/staticcheck@2023.1.7 &&
-        cd ${{ matrix.package }} &&
-        staticcheck -f stylish ./...
+      - name: staticcheck
+        run: >
+          go install honnef.co/go/tools/cmd/staticcheck@2023.1.7 &&
+          cd ${{ matrix.package }} &&
+          staticcheck -f stylish ./...
 
   build-otelcol-influxdb:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version: "1.22"
-
-    - name: build
-      run: >
-        go install go.opentelemetry.io/collector/cmd/builder@v0.101.0 &&
-        cd otelcol-influxdb &&
-        builder --config build.yml
+      - name: build
+        run: >
+          go install go.opentelemetry.io/collector/cmd/builder@v0.101.0 &&
+          cd otelcol-influxdb &&
+          builder --config build.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: staticcheck
         run: >
-          go install honnef.co/go/tools/cmd/staticcheck@2023.1.7 &&
+          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1 &&
           cd ${{ matrix.package }} &&
           staticcheck -f stylish ./...
 

--- a/jaeger-influxdb/internal/logctx.go
+++ b/jaeger-influxdb/internal/logctx.go
@@ -6,13 +6,13 @@ import (
 	"go.uber.org/zap"
 )
 
-var loggerContext struct{}
+type loggerContext struct{}
 
 func LoggerWithContext(ctx context.Context, logger *zap.Logger) context.Context {
-	return context.WithValue(ctx, loggerContext, logger)
+	return context.WithValue(ctx, loggerContext{}, logger)
 }
 
 func LoggerFromContext(ctx context.Context) *zap.Logger {
-	logger, _ := ctx.Value(loggerContext).(*zap.Logger)
+	logger, _ := ctx.Value(loggerContext{}).(*zap.Logger)
 	return logger
 }


### PR DESCRIPTION
Update the go versions used in CI to the currently supported versions 1.23 ans 1.24. This will allow dependabot to update dependencies.