### PR TITLE
chore(ci): update Go matrix to 1.25/1.26 and staticcheck to v0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.23", "1.24"]
+        go: ["1.25", "1.26"]
         package:
           [
             "common",
@@ -46,7 +46,7 @@ jobs:
 
       - name: staticcheck
         run: >
-          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1 &&
+          go install honnef.co/go/tools/cmd/staticcheck@v0.7.0 &&
           cd ${{ matrix.package }} &&
           staticcheck -f stylish ./...
 
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - name: build
         run: >

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -11,7 +11,7 @@ if ! hash go; then
 fi
 if ! hash staticcheck; then
   echo "installing staticcheck"
-  if ! go install honnef.co/go/tools/cmd/staticcheck@2023.1.7; then
+  if ! go install honnef.co/go/tools/cmd/staticcheck@v0.7.0; then
     echo "failed to install staticcheck"
     exit 1
   fi


### PR DESCRIPTION
The dependabot PRs (#342-#345, #347) bump x/net v0.55.0 / x/crypto v0.52.0, which require Go >= 1.25, so they also raise the modules' go directive to 1.25.0. CI still runs Go 1.23/1.24, so staticcheck v0.6.1 fails ("module requires at least go1.25.0") and tests-integration can't load the locally replaced sibling modules on the older toolchain.

Changes:
- CI matrix: Go 1.23/1.24 -> 1.25/1.26
- staticcheck: v0.6.1 -> v0.7.0 (here and in run-checks.sh)
- build-otelcol-influxdb job: Go 1.23 -> 1.25

Once merged, the dependabot PRs just need a rebase.